### PR TITLE
Agent panic if username fetch fails

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -221,7 +221,7 @@ func handleConn(conn net.Conn) {
 			hostname = "UNKNOWN"
 		}
 
-		userinfo, _ := user.Current()
+		userinfo, err := user.Current()
 		if err != nil {
 			username = "Unknown"
 		} else {


### PR DESCRIPTION
Currently, the agent will just crash if the username fetch fails due to a missing err check. Not sure if there's an easy way to reproduce this for others, though it has happened on Windows with the `iis apppool\defaultapppool` user making it impossible to use the agent otherwise.