### PR TITLE
Adding websockets protocol + additional features

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -24,8 +24,9 @@ func main() {
 	var socksProxy = flag.String("proxy", "", "proxy URL address (http://admin:secret@127.0.0.1:8080)"+
 		" or socks://admin:secret@127.0.0.1:8080")
 	var serverAddr = flag.String("connect", "", "the target (domain:port)")
+	var serverName = flag.String("sname", "", "SNI (server name in TLS)")
 	var userAgent = flag.String("ua", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "+
-		"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36", "http User-Agent")
+		"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36", "HTTP User-Agent")
 
 	flag.Parse()
 
@@ -62,6 +63,10 @@ func main() {
 			logrus.Fatal("Invalid connect address, please use host:port")
 		}
 		tlsConfig.ServerName = host
+	}
+
+	if *serverName != "" {
+		tlsConfig.ServerName = *serverName
 	}
 
 	if *ignoreCertificate {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -15,7 +15,7 @@ func main() {
 	var tlsConfig tls.Config
 	var ignoreCertificate = flag.Bool("ignore-cert", false, "ignore TLS certificate validation (dangerous), only for debug purposes")
 	var verbose = flag.Bool("v", false, "enable verbose mode")
-	var retry = flag.Bool("retry", false, "auto-retry on error")
+	var retry = flag.Int("retry", 0, "auto-retry on error with delay in sec. If 0 then no auto-retry")
 	var socksProxy = flag.String("socks", "", "socks5 proxy address (ip:port)")
 	var socksUser = flag.String("socks-user", "", "socks5 username")
 	var socksPass = flag.String("socks-pass", "", "socks5 password")
@@ -58,9 +58,9 @@ func main() {
 			err = connect(conn, &tlsConfig)
 		}
 		logrus.Errorf("Connection error: %v", err)
-		if *retry {
-			logrus.Info("Retrying in 5 seconds.")
-			time.Sleep(5 * time.Second)
+		if *retry > 0 {
+			logrus.Infof("Retrying in %d seconds.", *retry)
+			time.Sleep(time.Duration(*retry) * time.Second)
 		} else {
 			logrus.Fatal(err)
 		}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"github.com/hashicorp/yamux"
@@ -8,6 +9,10 @@ import (
 	"github.com/sirupsen/logrus"
 	goproxy "golang.org/x/net/proxy"
 	"net"
+	"net/http"
+	"net/url"
+	"nhooyr.io/websocket"
+	"strings"
 	"time"
 )
 
@@ -16,10 +21,11 @@ func main() {
 	var ignoreCertificate = flag.Bool("ignore-cert", false, "ignore TLS certificate validation (dangerous), only for debug purposes")
 	var verbose = flag.Bool("v", false, "enable verbose mode")
 	var retry = flag.Int("retry", 0, "auto-retry on error with delay in sec. If 0 then no auto-retry")
-	var socksProxy = flag.String("socks", "", "socks5 proxy address (ip:port)")
-	var socksUser = flag.String("socks-user", "", "socks5 username")
-	var socksPass = flag.String("socks-pass", "", "socks5 password")
+	var socksProxy = flag.String("proxy", "", "proxy URL address (http://admin:secret@127.0.0.1:8080)"+
+		" or socks://admin:secret@127.0.0.1:8080")
 	var serverAddr = flag.String("connect", "", "the target (domain:port)")
+	var userAgent = flag.String("ua", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "+
+		"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36", "http User-Agent")
 
 	flag.Parse()
 
@@ -32,13 +38,34 @@ func main() {
 	if *serverAddr == "" {
 		logrus.Fatal("please, specify the target host user -connect host:port")
 	}
-	host, _, err := net.SplitHostPort(*serverAddr)
-	if err != nil {
-		logrus.Fatal("invalid connect address, please use host:port")
+
+	if strings.Contains(*serverAddr, "https://") {
+		//websocket https connection
+		host, _, err := net.SplitHostPort(strings.Replace(*serverAddr, "https://", "", 1))
+		if err != nil {
+			logrus.Info("There is no port in address string, assuming that port is 443")
+			host = strings.Replace(*serverAddr, "https://", "", 1)
+		}
+		tlsConfig.ServerName = host
+	} else if strings.Contains(*serverAddr, "http://") {
+		//websocket http connection
+		host, _, err := net.SplitHostPort(strings.Replace(*serverAddr, "http://", "", 1))
+		if err != nil {
+			logrus.Info("There is no port in address string, assuming that port is 80")
+			host = strings.Replace(*serverAddr, "http://", "", 1)
+		}
+		tlsConfig.ServerName = host
+	} else {
+		//direct connection
+		host, _, err := net.SplitHostPort(*serverAddr)
+		if err != nil {
+			logrus.Fatal("Invalid connect address, please use host:port")
+		}
+		tlsConfig.ServerName = host
 	}
-	tlsConfig.ServerName = host
+
 	if *ignoreCertificate {
-		logrus.Warn("warning, certificate validation disabled")
+		logrus.Warn("Warning, certificate validation disabled")
 		tlsConfig.InsecureSkipVerify = true
 	}
 
@@ -46,17 +73,43 @@ func main() {
 
 	for {
 		var err error
-		if *socksProxy != "" {
-			if _, _, err := net.SplitHostPort(*socksProxy); err != nil {
-				logrus.Fatal("invalid socks5 address, please use host:port")
-			}
-			conn, err = sockDial(*serverAddr, *socksProxy, *socksUser, *socksPass)
+		if strings.Contains(*serverAddr, "http://") || strings.Contains(*serverAddr, "https://") ||
+			strings.Contains(*serverAddr, "wss://") || strings.Contains(*serverAddr, "ws://") {
+			*serverAddr = strings.Replace(*serverAddr, "https://", "wss://", 1)
+			*serverAddr = strings.Replace(*serverAddr, "http://", "ws://", 1)
+			//websocket
+			err = wsconnect(&tlsConfig, *serverAddr, *socksProxy, *userAgent)
 		} else {
-			conn, err = net.Dial("tcp", *serverAddr)
+			if *socksProxy != "" {
+				if strings.Contains(*socksProxy, "http://") {
+					//TODO http proxy CONNECT
+				} else {
+					//suppose that scheme is socks:// or socks5://
+					var proxyUrl *url.URL
+					proxyUrl, err = url.Parse(*socksProxy)
+					if err != nil {
+						logrus.Fatal("invalid socks5 address, please use host:port")
+					}
+					if _, _, err = net.SplitHostPort(proxyUrl.Host); err != nil {
+						logrus.Fatal("invalid socks5 address, please use socks://host:port")
+					}
+					pass, _ := proxyUrl.User.Password()
+					conn, err = sockDial(*serverAddr, proxyUrl.Host, proxyUrl.User.Username(), pass)
+					if err != nil {
+						logrus.Errorf("Socks connection error: %v", err)
+					} else {
+						logrus.Infof("Connection to socks success.")
+					}
+				}
+			} else {
+				//direct connection
+				conn, err = net.Dial("tcp", *serverAddr)
+			}
+			if err == nil {
+				err = connect(conn, &tlsConfig)
+			}
 		}
-		if err == nil {
-			err = connect(conn, &tlsConfig)
-		}
+
 		logrus.Errorf("Connection error: %v", err)
 		if *retry > 0 {
 			logrus.Infof("Retrying in %d seconds.", *retry)
@@ -85,9 +138,7 @@ func connect(conn net.Conn, config *tls.Config) error {
 	if err != nil {
 		return err
 	}
-
 	logrus.WithFields(logrus.Fields{"addr": tlsConn.RemoteAddr()}).Info("Connection established")
-
 	for {
 		conn, err := yamuxConn.Accept()
 		if err != nil {
@@ -95,4 +146,66 @@ func connect(conn net.Conn, config *tls.Config) error {
 		}
 		go agent.HandleConn(conn)
 	}
+}
+
+func wsconnect(config *tls.Config, wsaddr string, proxystr string, useragent string) error {
+	var nossl bool
+
+	if strings.Contains(wsaddr, "ws://") {
+		nossl = true
+	} else {
+		nossl = false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	defer cancel()
+
+	//proxystr = "http://admin:secret@127.0.0.1:8080"
+	proxyUrl, err := url.Parse(proxystr)
+	if err != nil || proxystr == "" {
+		proxyUrl = nil
+	}
+
+	httpTransport := &http.Transport{}
+	config.MinVersion = tls.VersionTLS10
+
+	if nossl {
+		httpTransport = &http.Transport{
+			MaxIdleConns: http.DefaultMaxIdleConnsPerHost,
+			Proxy:        http.ProxyURL(proxyUrl),
+		}
+	} else {
+		httpTransport = &http.Transport{
+			MaxIdleConns:    http.DefaultMaxIdleConnsPerHost,
+			TLSClientConfig: config,
+			Proxy:           http.ProxyURL(proxyUrl),
+		}
+	}
+
+	httpClient := &http.Client{Transport: httpTransport}
+	httpheader := &http.Header{}
+	httpheader.Add("User-Agent", useragent)
+
+	wsConn, _, err := websocket.Dial(ctx, wsaddr, &websocket.DialOptions{HTTPClient: httpClient, HTTPHeader: *httpheader})
+	if err != nil {
+		return err
+	}
+
+	netctx, cancel := context.WithTimeout(context.Background(), time.Hour*999999)
+	netConn := websocket.NetConn(netctx, wsConn, websocket.MessageBinary)
+	defer cancel()
+	yamuxConn, err := yamux.Server(netConn, yamux.DefaultConfig())
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Websocket connection established")
+	for {
+		conn, err := yamuxConn.Accept()
+		if err != nil {
+			return err
+		}
+		go agent.HandleConn(conn)
+	}
+	//return nil
 }

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -19,6 +19,7 @@ func main() {
 	var enableSelfcert = flag.Bool("selfcert", false, "dynamically generate self-signed certificates")
 	var certFile = flag.String("certfile", "certs/cert.pem", "TLS server certificate")
 	var keyFile = flag.String("keyfile", "certs/key.pem", "TLS server key")
+	var autostart = flag.String("autostart", "", "autostarting tunnel on interface. Ex: -autostart ligolo1 ")
 	var domainWhitelist = flag.String("allow-domains", "", "autocert authorised domains, if empty, allow all domains, multiple domains should be comma-separated.")
 
 	flag.Parse()
@@ -70,6 +71,10 @@ func main() {
 
 			if err := app.RegisterAgent(agent); err != nil {
 				logrus.Errorf("could not register agent: %s", err.Error())
+			}
+
+			if *autostart != "" {
+				app.AutostartAgent(agent, *autostart)
 			}
 		}
 	}()

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,11 @@ require (
 	golang.zx2c4.com/wireguard v0.0.0-20220703234212-c31a7b1ab478
 )
 
-require github.com/nicocha30/gvisor-ligolo v0.0.0-20230726075806-989fa2c0a413
+require (
+	github.com/nicocha30/gvisor-ligolo v0.0.0-20230726075806-989fa2c0a413
+	golang.org/x/sys v0.15.0
+	nhooyr.io/websocket v1.8.10
+)
 
 require (
 	github.com/desertbit/closer/v3 v3.1.3 // indirect
@@ -34,7 +38,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect


### PR DESCRIPTION
Hi again )
I re-coded my websocket branch  according your December commits:

- Mainly added websocket support. This is very useful when you trying to hide C2 server behind CDN (such as Cloudflare of AWS Cloudfront)
- Added auto-start agent feature
- Added httpproxy support. username and password field moved to proxy Url. ex: socks://admin:secret@127.0.0.1:1080 or http://admin:secret@127.0.0.1:8080
- Added agent sname param to covering you C2 domain by google.com or microsoft.com ))

Please review commits and merge it..
Regards
