### PR TITLE
Remove calls to logrus.Fatal() and panic() in library components

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"flag"
+	"os"
+	"strings"
+
 	"github.com/desertbit/grumble"
 	"github.com/hashicorp/yamux"
 	"github.com/nicocha30/ligolo-ng/cmd/proxy/app"
 	"github.com/nicocha30/ligolo-ng/pkg/controller"
 	"github.com/sirupsen/logrus"
-	"os"
-	"strings"
 )
 
 func main() {
@@ -48,7 +49,9 @@ func main() {
 	go proxyController.ListenAndServe()
 
 	// Wait for listener
-	proxyController.WaitForReady()
+	if err := proxyController.WaitForReady(); err != nil {
+		logrus.Fatal(err)
+	}
 
 	// Agent registration goroutine
 	go func() {

--- a/pkg/agent/handler.go
+++ b/pkg/agent/handler.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/nicocha30/ligolo-ng/pkg/agent/neterror"
-	"github.com/nicocha30/ligolo-ng/pkg/agent/smartping"
-	"github.com/nicocha30/ligolo-ng/pkg/protocol"
-	"github.com/nicocha30/ligolo-ng/pkg/relay"
-	"github.com/sirupsen/logrus"
 	"net"
 	"os"
 	"os/user"
 	"syscall"
 	"time"
+
+	"github.com/nicocha30/ligolo-ng/pkg/agent/neterror"
+	"github.com/nicocha30/ligolo-ng/pkg/agent/smartping"
+	"github.com/nicocha30/ligolo-ng/pkg/protocol"
+	"github.com/nicocha30/ligolo-ng/pkg/relay"
+	"github.com/sirupsen/logrus"
 )
 
 var listenerConntrack map[int32]net.Conn
@@ -80,7 +81,8 @@ func NewUDPListener(network string, addr string) (UDPListener, error) {
 func HandleConn(conn net.Conn) {
 	decoder := protocol.NewDecoder(conn)
 	if err := decoder.Decode(); err != nil {
-		panic(err)
+		logrus.Error(err)
+		return
 	}
 
 	e := decoder.Envelope.Payload
@@ -127,7 +129,8 @@ func HandleConn(conn net.Conn) {
 			Type:    protocol.MessageConnectResponse,
 			Payload: connectPacket,
 		}); err != nil {
-			logrus.Fatal(err)
+			logrus.Error(err)
+			return
 		}
 		if connectPacket.Established {
 			relay.StartRelay(targetConn, conn)
@@ -142,7 +145,8 @@ func HandleConn(conn net.Conn) {
 			Type:    protocol.MessageHostPingResponse,
 			Payload: pingResponse,
 		}); err != nil {
-			logrus.Fatal(err)
+			logrus.Error(err)
+			return
 		}
 	case protocol.MessageInfoRequest:
 		var username string
@@ -173,7 +177,8 @@ func HandleConn(conn net.Conn) {
 			Type:    protocol.MessageInfoReply,
 			Payload: infoResponse,
 		}); err != nil {
-			logrus.Fatal(err)
+			logrus.Error(err)
+			return
 		}
 	case protocol.MessageListenerCloseRequest:
 		// Request to close a listener
@@ -325,7 +330,8 @@ func HandleConn(conn net.Conn) {
 			Type:    protocol.MessageListenerSockResponse,
 			Payload: sockResponse,
 		}); err != nil {
-			logrus.Fatal(err)
+			logrus.Error(err)
+			return
 		}
 
 		if sockResponse.Err {

--- a/pkg/protocol/decoder.go
+++ b/pkg/protocol/decoder.go
@@ -42,85 +42,85 @@ func (d *LigoloDecoder) Decode() error {
 	case MessageInfoRequest:
 		p := InfoRequestPacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageInfoReply:
 		p := InfoReplyPacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageConnectRequest:
 		p := ConnectRequestPacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageConnectResponse:
 		p := ConnectResponsePacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageHostPingRequest:
 		p := HostPingRequestPacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageHostPingResponse:
 		p := HostPingResponsePacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageListenerRequest:
 		p := ListenerRequestPacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageListenerResponse:
 		p := ListenerResponsePacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageListenerBindRequest:
 		p := ListenerBindPacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageListenerBindResponse:
 		p := ListenerBindReponse{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageListenerSockRequest:
 		p := ListenerSockRequestPacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageListenerSockResponse:
 		p := ListenerSockResponsePacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageListenerCloseRequest:
 		p := ListenerCloseRequestPacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	case MessageListenerCloseResponse:
 		p := ListenerCloseResponsePacket{}
 		if err := gobdecoder.Decode(&p); err != nil {
-			panic(err)
+			return err
 		}
 		d.Envelope.Payload = p
 	default:

--- a/pkg/proxy/netstack/icmp.go
+++ b/pkg/proxy/netstack/icmp.go
@@ -3,6 +3,7 @@ package netstack
 import (
 	"bytes"
 	"errors"
+
 	"github.com/nicocha30/gvisor-ligolo/pkg/buffer"
 	"github.com/nicocha30/gvisor-ligolo/pkg/tcpip"
 	"github.com/nicocha30/gvisor-ligolo/pkg/tcpip/checksum"
@@ -48,7 +49,8 @@ func icmpResponder(s *NetStack) error {
 							continue
 						} else {
 							// This is bad.
-							panic(err)
+							logrus.Error(err)
+							return
 						}
 					}
 
@@ -171,7 +173,7 @@ func ProcessICMP(nstack *stack.Stack, pkt stack.PacketBufferPtr) {
 		replyPkt.TransportProtocolNumber = header.ICMPv4ProtocolNumber
 
 		if err := r.WriteHeaderIncludedPacket(replyPkt); err != nil {
-			panic(err)
+			logrus.Error(err)
 			return
 		}
 	}


### PR DESCRIPTION
I use the ligolo-ng library packages in my own application, and noticed when attempting to listen on a port that was already in use, instead of returning an error the whole program would exit due to a call to `logrus.Fatal`. According to [Go best practices](https://go.dev/doc/effective_go#panic), libraries should avoid exposing panics and prefer to log/return errors when possible (and I would say this extends to functions like logrus.Fatal), so that's what this PR attempts to do. It also adds a check to make sure port 80 is available before starting a web server for Let's Encrypt cert generation.

Thanks for all your work on ligolo-ng, it is a fantastic tool!

