### PR TITLE
Add version flags to proxy and agent

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"github.com/hashicorp/yamux"
 	"github.com/nicocha30/ligolo-ng/pkg/agent"
+	"github.com/nicocha30/ligolo-ng/pkg/common"
 	"github.com/sirupsen/logrus"
 	goproxy "golang.org/x/net/proxy"
 	"net"
@@ -14,6 +15,7 @@ import (
 func main() {
 	var tlsConfig tls.Config
 	var ignoreCertificate = flag.Bool("ignore-cert", false, "ignore TLS certificate validation (dangerous), only for debug purposes")
+	var version = flag.Bool("version", false, "print version information and exit")
 	var verbose = flag.Bool("v", false, "enable verbose mode")
 	var retry = flag.Bool("retry", false, "auto-retry on error")
 	var socksProxy = flag.String("socks", "", "socks5 proxy address (ip:port)")
@@ -24,6 +26,11 @@ func main() {
 	flag.Parse()
 
 	logrus.SetReportCaller(*verbose)
+
+	if *version {
+		common.PrintVersion()
+		return
+	}
 
 	if *verbose {
 		logrus.SetLevel(logrus.DebugLevel)

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -8,14 +8,16 @@ import (
 	"github.com/desertbit/grumble"
 	"github.com/hashicorp/yamux"
 	"github.com/nicocha30/ligolo-ng/cmd/proxy/app"
+	"github.com/nicocha30/ligolo-ng/pkg/common"
 	"github.com/nicocha30/ligolo-ng/pkg/controller"
 	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	var allowDomains []string
+	var version = flag.Bool("version", false, "print version information and exit")
 	var verboseFlag = flag.Bool("v", false, "enable verbose mode")
-	var listenInterface = flag.String("laddr", "0.0.0.0:11601", "listening address ")
+	var listenInterface = flag.String("laddr", "0.0.0.0:11601", "listening address")
 	var enableAutocert = flag.Bool("autocert", false, "automatically request letsencrypt certificates, requires port 80 to be accessible")
 	var enableSelfcert = flag.Bool("selfcert", false, "dynamically generate self-signed certificates")
 	var certFile = flag.String("certfile", "certs/cert.pem", "TLS server certificate")
@@ -23,6 +25,11 @@ func main() {
 	var domainWhitelist = flag.String("allow-domains", "", "autocert authorised domains, if empty, allow all domains, multiple domains should be comma-separated.")
 
 	flag.Parse()
+
+	if *version {
+		common.PrintVersion()
+		return
+	}
 
 	if *verboseFlag {
 		logrus.SetLevel(logrus.DebugLevel)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,0 +1,9 @@
+package common
+
+import "fmt"
+
+const Version = "v0.5.2"
+
+func PrintVersion() {
+	fmt.Printf("ligolo-ng %s\n", Version)
+}


### PR DESCRIPTION
Fixes #59. To get the version, you can run either `./agent -version` or `./proxy -version`. Didn't use `-v` because that is already used for verbose mode.

I implemented this in a separate common package as that was what I thought would be the simplest and easiest to maintain (and allow for adding more common functions between the proxy and agent in the future).

The downside is that the version number will need to be changed whenever a new version is released. I'm not too familiar with the CI, but an improvement could be to automatically set the version to the tag name within the CI (or do it though go build somehow).