### PR TITLE
Fix listener errors when manually stopping

### DIFF
--- a/cmd/proxy/app/app.go
+++ b/cmd/proxy/app/app.go
@@ -399,7 +399,9 @@ func Run() {
 						}
 						return
 					}
+
 					logrus.WithFields(logrus.Fields{"listener": listener.String()}).Warning("Listener ended without error.")
+					return
 				}
 			}()
 

--- a/pkg/proxy/listeners.go
+++ b/pkg/proxy/listeners.go
@@ -97,7 +97,7 @@ func (l *LigoloListener) relayTCP() error {
 		if err := ligoloProtocol.Decode(); err != nil {
 			if err == io.EOF {
 				// Listener closed.
-				return err
+				return nil
 			}
 			return err
 		}


### PR DESCRIPTION
Fixes #56.

This fixes three errors when using `listener_stop <id>` in a session:
1. Stopping a TCP listener without the --no-retry flag continuously prints a message about retrying the listener
2. Stopping a TCP listener with the --no-retry flag prints an error about EOF and exits (not technically an issue as the message is true, but there's no reason for this message)
3. A listener the ends without errors (e.g. a UDP listener before this fix) would endlessly print "Listener ended without error."

Because line 102 in `pkg/proxy/listeners.go` already returns an error, it seems to me that having the `err == io.EOF` check should return nil, otherwise there is no point in having it (and it fixes 2 of the 3 errors mentioned above).