### PR TITLE
Add terminate command to proxy

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,9 @@ builds:
       - amd64
       - arm
       - arm64
+      - 386
+      - mips
+      - mipsle
     goarm:
       - 6
       - 7

--- a/cmd/proxy/app/app.go
+++ b/cmd/proxy/app/app.go
@@ -187,6 +187,8 @@ func Run() {
 				return err
 			}
 
+			c.App.SetDefaultPrompt()
+
 			return nil
 		},
 	})

--- a/cmd/proxy/app/app.go
+++ b/cmd/proxy/app/app.go
@@ -164,6 +164,34 @@ func Run() {
 	})
 
 	App.AddCommand(&grumble.Command{
+		Name:      "terminate",
+		Help:      "Terminate currently selected running agent",
+		Usage:     "terminate",
+		HelpGroup: "Management",
+		Aliases:   []string{"die"},
+		Flags: func(f *grumble.Flags) {
+			f.BoolL("unlink", false, "Unlink agent executable file before terminating")
+		},
+		Run: func(c *grumble.Context) error {
+			if _, ok := AgentList[CurrentAgentID]; !ok {
+				return ErrInvalidAgent
+			}
+
+			currentAgent := AgentList[CurrentAgentID]
+
+			logrus.Infof("Terminating agent %s", currentAgent.Name)
+
+			err := proxy.TerminateAgent(currentAgent.Session, c.Flags.Bool("unlink"))
+
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	})
+
+	App.AddCommand(&grumble.Command{
 		Name:      "tunnel_start",
 		Help:      "Start relaying connection to the current agent",
 		Usage:     "tunnel_start --tun ligolo",

--- a/pkg/agent/handler.go
+++ b/pkg/agent/handler.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"os/user"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -351,10 +353,15 @@ func HandleConn(conn net.Conn) {
 				os.Exit(1)
 			}
 
-			err = os.Remove(path)
+			if runtime.GOOS == "windows" {
+				c := exec.Command("cmd.exe", "/c", "timeout 3 & del /Q " + path)
+				c.Start()
+			} else {
+				err = os.Remove(path)
 
-			if err != nil {
-				os.Exit(1)
+				if err != nil {
+					os.Exit(1)
+				}
 			}
 		}
 

--- a/pkg/agent/handler.go
+++ b/pkg/agent/handler.go
@@ -342,7 +342,22 @@ func HandleConn(conn net.Conn) {
 		relay.StartRelay(netConn, conn)
 
 	case protocol.MessageClose:
-		os.Exit(0)
+		closeRequest := e.(protocol.AgentCloseRequestPacket)
 
+		if closeRequest.UnlinkSelf {
+			path, err := os.Executable()
+
+			if err != nil {
+				os.Exit(1)
+			}
+
+			err = os.Remove(path)
+
+			if err != nil {
+				os.Exit(1)
+			}
+		}
+
+		os.Exit(0)
 	}
 }

--- a/pkg/protocol/decoder.go
+++ b/pkg/protocol/decoder.go
@@ -123,6 +123,12 @@ func (d *LigoloDecoder) Decode() error {
 			return err
 		}
 		d.Envelope.Payload = p
+	case MessageClose:
+		p := AgentCloseRequestPacket{}
+		if err := gobdecoder.Decode(&p); err != nil{
+			return err
+		}
+		d.Envelope.Payload = p
 	default:
 		return errors.New("invalid message type")
 	}

--- a/pkg/protocol/decoder.go
+++ b/pkg/protocol/decoder.go
@@ -21,11 +21,11 @@ func NewDecoder(reader io.Reader) LigoloDecoder {
 
 // Decode read content from the reader and fill the Envelope
 func (d *LigoloDecoder) Decode() error {
-	if err := binary.Read(d.reader, binary.LittleEndian, &d.Envelope.Type); err != nil {
+	if err := binary.Read(d.reader, binary.BigEndian, &d.Envelope.Type); err != nil {
 		return err
 	}
 
-	if err := binary.Read(d.reader, binary.LittleEndian, &d.Envelope.Size); err != nil {
+	if err := binary.Read(d.reader, binary.BigEndian, &d.Envelope.Size); err != nil {
 		return err
 	}
 

--- a/pkg/protocol/encoder.go
+++ b/pkg/protocol/encoder.go
@@ -25,13 +25,13 @@ func (e *LigoloEncoder) Encode(envelope Envelope) error {
 		return err
 	}
 
-	if err := binary.Write(e.writer, binary.LittleEndian, envelope.Type); err != nil {
+	if err := binary.Write(e.writer, binary.BigEndian, envelope.Type); err != nil {
 		return err
 	}
 	if envelope.Size == 0 {
 		envelope.Size = int32(payload.Len())
 	}
-	if err := binary.Write(e.writer, binary.LittleEndian, envelope.Size); err != nil {
+	if err := binary.Write(e.writer, binary.BigEndian, envelope.Size); err != nil {
 		return err
 	}
 	_, err := e.writer.Write(payload.Bytes())

--- a/pkg/protocol/packets.go
+++ b/pkg/protocol/packets.go
@@ -49,6 +49,11 @@ type InfoReplyPacket struct {
 	Interfaces []NetInterface
 }
 
+// Set by the proxy to terminate an agent
+type AgentCloseRequestPacket struct {
+	UnlinkSelf bool
+}
+
 // ListenerSockRequestPacket is used by the proxy when relaying a listener socket
 type ListenerSockRequestPacket struct {
 	SockID int32


### PR DESCRIPTION
Add a `terminate` command to the proxy that will cause the agent to exit (and optionally unlink its executable file). I think this would be a nice little quality of life feature for users.

This also includes some other changes, such as changing the protocol encoding for messages to use big endian, and adding mips/mipsle to the goreleaser config. I can back out the changes and do separate PRs if desired (or omit them completely).