### PR TITLE
fix nil deref on latest agent

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	serverUrl, err := url.Parse(*serverAddr)
-	if err != nil && serverUrl != nil {
+	if err == nil && serverUrl != nil {
 		if serverUrl.Scheme == "https" {
 			//websocket https connection
 			tlsConfig.ServerName = serverUrl.Hostname()


### PR DESCRIPTION
Got the following when attempting to run the latest agent release:

```console
$ ./agent -ignore-cert -retry -connect 127.0.0.1:11601
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6d77a3]

goroutine 1 [running]:
main.main()
	/home/runner/work/ligolo-ng/ligolo-ng/cmd/agent/main.go:102 +0x363
$
```

Looks like this was caused by the recent websocket merge. The nil deref occurs when a websocket connection is not specified, and a direct TCP connection is attempted.