### PR TITLE
Add session id to join/drop messages and added mac make target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ $(shell mkdir -p ${BASEDIR})
 all: linux windows
 	@chmod +x dist/*
 
+mac: lint
+	@env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath ${LDFLAGS} ${GCFLAGS} ${ASMFLAGS} -o ${BASEDIR}/ligolo-ng-proxy-darwin_amd64 cmd/proxy/main.go
+	@env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath ${LDFLAGS} ${GCFLAGS} ${ASMFLAGS} -o ${BASEDIR}/ligolo-ng-agent-darwin_amd64 cmd/agent/main.go
+
 linux: lint
 	@env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath ${LDFLAGS} ${GCFLAGS} ${ASMFLAGS} -o ${BASEDIR}/ligolo-ng-proxy-linux_amd64 cmd/proxy/main.go
 	@env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath ${LDFLAGS} ${GCFLAGS} ${ASMFLAGS} -o ${BASEDIR}/ligolo-ng-agent-linux_amd64 cmd/agent/main.go

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -108,7 +108,7 @@ func main() {
 				continue
 			}
 
-			logrus.WithFields(logrus.Fields{"remote": remoteConn.RemoteAddr(), "name": agent.Name}).Info("Agent joined.")
+			logrus.WithFields(logrus.Fields{"remote": remoteConn.RemoteAddr(), "name": agent.Name, "id": agent.SessionID}).Info("Agent joined.")
 
 			if err := app.RegisterAgent(agent); err != nil {
 				logrus.Errorf("could not register agent: %s", err.Error())
@@ -119,7 +119,7 @@ func main() {
 				for {
 					select {
 					case <-agent.Session.CloseChan(): // Agent closed
-						logrus.Warnf("Lost ligolo-ng connection with agent %s!", agent.Name)
+						logrus.WithFields(logrus.Fields{"remote": remoteConn.RemoteAddr(), "name": agent.Name, "id": agent.SessionID}).Warnf("Lost ligolo-ng connection with agent!")
 						return
 					}
 				}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -119,7 +119,7 @@ func main() {
 				for {
 					select {
 					case <-agent.Session.CloseChan(): // Agent closed
-						logrus.WithFields(logrus.Fields{"remote": remoteConn.RemoteAddr(), "name": agent.Name, "id": agent.SessionID}).Warnf("Lost ligolo-ng connection with agent!")
+						logrus.WithFields(logrus.Fields{"remote": remoteConn.RemoteAddr(), "name": agent.Name, "id": agent.SessionID}).Warnf("Agent dropped.")
 						return
 					}
 				}


### PR DESCRIPTION
I had missed these two notification messages in the previous MR. Added them for completeness. Also added an optional mac make target to make building for mac more readily available.