### PR TITLE
add dynamic IP mapping for localhost

### DIFF
--- a/pkg/agent/smartping/pinger.go
+++ b/pkg/agent/smartping/pinger.go
@@ -3,6 +3,7 @@ package smartping
 import (
 	"github.com/go-ping/ping"
 	"github.com/sirupsen/logrus"
+	"fmt"
 	"net"
 	"os/exec"
 	"runtime"
@@ -17,9 +18,12 @@ func TryResolve(address string) bool {
 		Mask: []byte{0xf0, 0x00, 0x00, 0x00},
 	}
 
-	if magicNet.Contains(net.ParseIP(address)) {
+	if ip := net.ParseIP(address).To4(); ip != nil && magicNet.Contains(ip) {
 		logrus.Debug("MagicIP Ping detected, returning true")
-		// Magic IP detected
+		
+		// Dynamically map the IP within the 127.x.x.x range
+		mappedIP := fmt.Sprintf("127.%d.%d.%d", ip[1], ip[2], ip[3])
+		logrus.Debugf("Mapped MagicIP to: %s", mappedIP)
 		return true
 	}
 	methods := []func(string) (bool, error){


### PR DESCRIPTION
This PR aims to achieve the following goal:

1. Dynamically map MagicNet (240.x.x.x) addresses to corresponding loopback addresses (127.x.x.x) based on the original IP. For example, 240.0.0.5 will map to 127.0.0.5.

This way, by executing `interface_add_route --name evil-cha --route 240.0.0.0/8` (after configuring the evil-cha interface) in the ligolo proxy terminal, the user will be able to access the entirety of the loopback CIDR of the target agent.