### PR TITLE
feat: add --api-laddr flag and fix TLS initialization bug

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -54,6 +54,7 @@ func main() {
 	var hideBanner = flag.Bool("nobanner", false, "don't show banner on startup")
 	var configFile = flag.String("config", "", "the config file to use")
 	var daemonMode = flag.Bool("daemon", false, "run as daemon mode (no CLI)")
+	var apiListenAddr = flag.String("api-laddr", "", "API server listening address (default: 127.0.0.1:8080)")
 	var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to `file`")
 	var memprofile = flag.String("memprofile", "", "write memory profile to `file`")
 
@@ -79,6 +80,10 @@ func main() {
 	}
 
 	config.InitConfig(*configFile)
+
+	if *apiListenAddr != "" {
+		config.Config.Set("web.listen", *apiListenAddr)
+	}
 
 	if *versionFlag {
 		fmt.Printf("Ligolo-ng %s / %s / %s\n", version, commit, date)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -106,6 +106,12 @@ func (c *Controller) ListenAndServe() {
 		err = s.Serve(listener)
 	} else if url.IsValid() {
 		//direct listen with legacy ligolo-ng protocol
+		tlsConfig, err := tlsutils.CertManager(c.CertManagerConfig)
+		if err != nil {
+			c.startchan <- err
+			return
+		}
+		c.tlsConfig = tlsConfig
 		listener, err := tls.Listen(c.Network, url.Host, c.tlsConfig)
 		if err != nil {
 			c.startchan <- err


### PR DESCRIPTION
- Added --api-laddr command-line flag to configure API server listening address
- Fixed TLS initialization bug in direct (non-websocket) connection mode

The TLS config was not being initialized before use in the direct listen path, causing "tls: neither Certificates, GetCertificate, nor GetConfigForClient set" error. Now properly initializes TLS config using CertManager before creating the TLS listener.