### PR TITLE
Add multi-hop agent chaining (relay mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ tunnels from a reverse TCP/TLS connection using a **tun interface** (without the
 - Reverse/Bind Connection
 - Automatic tunnel/listeners recovery (in case of network issues)
 - Websocket support
+- **Multi-hop agent chaining** for pivoting through segmented networks
 
 ## Demo
 
@@ -124,6 +125,41 @@ Connecting to host 10.10.0.1, port 24483
 [  5]   0.00-10.08  sec   125 MBytes   104 Mbits/sec                  receiver
 ```
 
+## Multi-Hop Agent Chaining
+
+Ligolo-ng supports relay mode, allowing agents to act as lightweight TLS relays for downstream agents. This enables pivoting through segmented networks where some hosts cannot reach the proxy directly.
+
+```
+Proxy <---> Agent A (relay) <---> Agent B ---> Target Network
+```
+
+**Setup:**
+
+1. Select an agent and start relay mode:
+```
+ligolo-ng » session             # select Agent A
+[Agent: user@DMZ] » relay_start --addr 0.0.0.0:11602
+```
+
+2. On the target host (in Agent A's network), connect through the relay:
+```
+./agent -connect <AgentA_IP>:11602 -ignore-cert
+```
+
+3. Agent B auto-registers on the proxy and can be used like any other agent (tunnels, listeners, etc.).
+
+**Commands:**
+- `relay_start --addr <ip:port>` - Start relay listener on the current agent
+- `relay_stop` - Stop relay on the current agent
+- `chain_list` - Display the relay chain topology
+
+**API endpoints:**
+- `POST /api/v1/relay/:id` - Start relay (body: `{"ListenAddr": "0.0.0.0:11602"}`)
+- `DELETE /api/v1/relay/:id` - Stop relay
+- `GET /api/v1/chains` - Get chain topology
+
+The maximum chain depth is 5 hops. Session recovery is supported across the full chain.
+
 ## Caveats
 
 Because the *agent* is running without privileges, it's not possible to forward raw packets.
@@ -135,7 +171,8 @@ When using *nmap*, you should use `--unprivileged` or `-PE` to avoid false posit
 
 - Implement other ICMP error messages (this will speed up UDP scans) ;
 - Do not *RST* when receiving an *ACK* from an invalid TCP connection (nmap will report the host as up) ;
-- Add mTLS support.
+- Add mTLS support ;
+- ~~Multi-hop agent chaining~~ (done).
 
 ## Credits
 

--- a/cmd/proxy/app/app.go
+++ b/cmd/proxy/app/app.go
@@ -47,6 +47,7 @@ import (
 var AgentList map[int]*controller.LigoloAgent
 var AgentListMutex sync.Mutex
 var ProxyController *controller.Controller
+var ChainMgr = proxy.NewChainManager()
 
 // CurrentAgentID points to the selected agent in the UI (when running session)
 var CurrentAgentID int
@@ -240,6 +241,36 @@ func RegisterAgent(agent *controller.LigoloAgent) error {
 				
 				logrus.Infof("Listener restored successfully: %s", proxyListener.String())
 			}
+
+			// Restore relay if it was previously active
+			if registeredAgents.RelayActive {
+				savedRelayAddr := registeredAgents.RelayListenAddr
+				// Reset relay state before restarting
+				registeredAgents.RelayActive = false
+				registeredAgents.RelayControl = nil
+
+				logrus.Infof("Restoring relay on agent %s at %s", registeredAgents.Name, savedRelayAddr)
+				fingerprint, err := registeredAgents.StartRelay(savedRelayAddr)
+				if err != nil {
+					logrus.Errorf("Failed to restore relay: %v", err)
+				} else {
+					logrus.Infof("Relay restored (fingerprint: %s). Downstream agents can reconnect.", fingerprint)
+					go registeredAgents.HandleRelayNotifications(ChainMgr, func(a *controller.LigoloAgent) error {
+						logrus.WithFields(logrus.Fields{
+							"name":    a.Name,
+							"session": a.SessionID,
+							"via":     registeredAgents.Name,
+						}).Info("Downstream agent reconnected via relay")
+						return RegisterAgent(a)
+					})
+				}
+			}
+
+			// Preserve parent agent ID for recovered downstream agents
+			if agent.ParentAgentID != "" {
+				registeredAgents.ParentAgentID = agent.ParentAgentID
+			}
+
 			return nil
 		}
 	}
@@ -563,7 +594,7 @@ func Run() {
 			t := table.NewWriter()
 			t.SetStyle(table.StyleLight)
 			t.SetTitle("Active sessions and tunnels")
-			t.AppendHeader(table.Row{"#", "Agent", "Interface", "Status"})
+			t.AppendHeader(table.Row{"#", "Agent", "Interface", "Via", "Status"})
 
 			AgentListMutex.Lock()
 			for id, agent := range AgentList {
@@ -573,7 +604,17 @@ func Run() {
 				} else {
 					status = text.Colors{text.FgRed}.Sprintf("Offline (Awaiting recovery)")
 				}
-				t.AppendRow(table.Row{id, agent.String(), agent.Interface, status})
+				via := "(direct)"
+				if agent.ParentAgentID != "" {
+					// Find parent agent name
+					for _, a := range AgentList {
+						if a.SessionID == agent.ParentAgentID {
+							via = fmt.Sprintf("via %s", a.Name)
+							break
+						}
+					}
+				}
+				t.AppendRow(table.Row{id, agent.String(), agent.Interface, via, status})
 			}
 			AgentListMutex.Unlock()
 			App.Println(t.Render())
@@ -828,6 +869,100 @@ App.AddCommand(&grumble.Command{
 			if ask("Are you sure to kill the current agent?") {
 				return currentAgent.Kill()
 			}
+			return nil
+		},
+	})
+
+	App.AddCommand(&grumble.Command{
+		Name:      "relay_start",
+		Help:      "Start relay mode on the current agent to accept downstream agents",
+		Usage:     "relay_start --addr 0.0.0.0:11602",
+		HelpGroup: "Relay",
+		Flags: func(f *grumble.Flags) {
+			f.StringL("addr", "0.0.0.0:11602", "The address:port the agent should listen on for downstream agents")
+		},
+		Run: func(c *grumble.Context) error {
+			if _, ok := AgentList[CurrentAgentID]; !ok {
+				return ErrInvalidAgent
+			}
+			currentAgent := AgentList[CurrentAgentID]
+			if currentAgent.Session == nil {
+				return ErrInvalidAgent
+			}
+			if !currentAgent.RelayCapable {
+				return errors.New("this agent does not support relay mode")
+			}
+			if currentAgent.RelayActive {
+				return fmt.Errorf("relay already active on %s", currentAgent.RelayListenAddr)
+			}
+
+			fingerprint, err := currentAgent.StartRelay(c.Flags.String("addr"))
+			if err != nil {
+				return fmt.Errorf("could not start relay: %v", err)
+			}
+
+			logrus.Infof("Relay started on agent %s at %s", currentAgent.Name, c.Flags.String("addr"))
+			logrus.Infof("TLS Certificate fingerprint: %s", fingerprint)
+			logrus.Infof("Downstream agents can connect with: ./agent -connect <agent_ip>:%s -ignore-cert", strings.Split(c.Flags.String("addr"), ":")[len(strings.Split(c.Flags.String("addr"), ":"))-1])
+
+			// Start listening for downstream agent notifications
+			go currentAgent.HandleRelayNotifications(ChainMgr, func(agent *controller.LigoloAgent) error {
+				logrus.WithFields(logrus.Fields{
+					"name":    agent.Name,
+					"session": agent.SessionID,
+					"via":     currentAgent.Name,
+				}).Info("Downstream agent connected via relay")
+				return RegisterAgent(agent)
+			})
+
+			return nil
+		},
+	})
+
+	App.AddCommand(&grumble.Command{
+		Name:      "relay_stop",
+		Help:      "Stop relay mode on the current agent",
+		Usage:     "relay_stop",
+		HelpGroup: "Relay",
+		Run: func(c *grumble.Context) error {
+			if _, ok := AgentList[CurrentAgentID]; !ok {
+				return ErrInvalidAgent
+			}
+			currentAgent := AgentList[CurrentAgentID]
+			if !currentAgent.RelayActive {
+				return errors.New("relay is not active on this agent")
+			}
+
+			downstream := ChainMgr.GetDownstreamSessionIDs(currentAgent.SessionID)
+			if len(downstream) > 0 {
+				if !ask(fmt.Sprintf("Stopping relay will disconnect %d downstream agent(s). Continue?", len(downstream))) {
+					return nil
+				}
+			}
+
+			return currentAgent.StopRelay()
+		},
+	})
+
+	App.AddCommand(&grumble.Command{
+		Name:      "chain_list",
+		Help:      "Show the relay chain topology",
+		Usage:     "chain_list",
+		HelpGroup: "Relay",
+		Run: func(c *grumble.Context) error {
+			AgentListMutex.Lock()
+			var agents []proxy.AgentInfo
+			for _, agent := range AgentList {
+				agents = append(agents, proxy.AgentInfo{
+					Name:        agent.Name,
+					SessionID:   agent.SessionID,
+					RelayActive: agent.RelayActive,
+					Alive:       agent.Alive(),
+				})
+			}
+			AgentListMutex.Unlock()
+
+			App.Println(ChainMgr.RenderTree(agents))
 			return nil
 		},
 	})

--- a/cmd/proxy/app/app.go
+++ b/cmd/proxy/app/app.go
@@ -98,7 +98,7 @@ func RegisterAgent(agent *controller.LigoloAgent) error {
 					}
 				}
 			}
-			
+
 			if sessionFunctional {
 				// Session is truly alive and working, reject duplicate
 				logrus.Infof("Agent %s already connected, rejecting duplicate from %s", agent.SessionID, agent.Session.RemoteAddr())
@@ -108,23 +108,23 @@ func RegisterAgent(agent *controller.LigoloAgent) error {
 				}
 				return fmt.Errorf("agent %s already connected", agent.SessionID)
 			}
-			
+
 			// Session is dead or non-functional, perform recovery
 			logrus.Infof("Recovering agent: %s (ID: %d)", registeredAgents.Name, agentID)
 			recovered = true
-			
+
 			// Close old session if it exists
 			if registeredAgents.Session != nil {
 				registeredAgents.Session.Close()
 			}
-			
+
 			// Update to new session
 			registeredAgents.Session = agent.Session
 
 			// FIXED: Check if tunnel was running and clean up properly
 			savedInterface := registeredAgents.Interface
 			tunnelWasRunning := registeredAgents.Running
-			
+
 			// ALWAYS restore tunnel if an interface was previously configured
 			if savedInterface != "" {
 				logrus.Infof("Restoring tunnel for agent %s on interface %s", registeredAgents.Name, savedInterface)
@@ -141,7 +141,7 @@ func RegisterAgent(agent *controller.LigoloAgent) error {
 
 				// Reset running flag
 				registeredAgents.Running = false
-				
+
 				// CRITICAL: Clean up any stale interface state
 				if netinfo.InterfaceExist(savedInterface) {
 					logrus.Infof("Cleaning up stale interface %s...", savedInterface)
@@ -170,7 +170,7 @@ func RegisterAgent(agent *controller.LigoloAgent) error {
 						time.Sleep(200 * time.Millisecond)
 					}
 				}
-				
+
 				// Recreate interface with fresh fd
 				logrus.Infof("Recreating interface %s...", savedInterface)
 				if err := netinfo.CreateTUN(savedInterface); err != nil {
@@ -223,14 +223,14 @@ func RegisterAgent(agent *controller.LigoloAgent) error {
 			// Now recreate listeners on the agent side with the new session
 			for _, listenerInfo := range listenersToRestore {
 				logrus.Infof("Restoring listener: [%s] %s => %s", listenerInfo.network, listenerInfo.listenerAddr, listenerInfo.redirectAddr)
-				
+
 				// AddListener will create a new listener on the agent side
 				proxyListener, err := registeredAgents.AddListener(listenerInfo.listenerAddr, listenerInfo.network, listenerInfo.redirectAddr)
 				if err != nil {
 					logrus.Errorf("Failed to restore listener: %v", err)
 					continue
 				}
-				
+
 				// Start the relay for the new listener
 				go func(l *proxy.LigoloListener, a *controller.LigoloAgent) {
 					err := l.StartRelay()
@@ -238,7 +238,7 @@ func RegisterAgent(agent *controller.LigoloAgent) error {
 						logrus.WithFields(logrus.Fields{"listener": l.String(), "agent": a.Name, "id": a.SessionID}).Warnf("Listener relay ended: %v", err)
 					}
 				}(proxyListener, registeredAgents)
-				
+
 				logrus.Infof("Listener restored successfully: %s", proxyListener.String())
 			}
 
@@ -285,7 +285,7 @@ func RegisterAgent(agent *controller.LigoloAgent) error {
 			}
 		}
 	}
-	
+
 	AgentCounter++
 	AgentList[AgentCounter] = agent
 	return nil
@@ -296,9 +296,9 @@ func StartTunnel(agent *controller.LigoloAgent, tunName string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	interfaceExists := netinfo.InterfaceExist(tunName)
-	
+
 	// Create interface if needed
 	if _, ok := configState[tunName]; ok {
 		if runtime.GOOS == "linux" && !interfaceExists {
@@ -351,7 +351,7 @@ func StartTunnel(agent *controller.LigoloAgent, tunName string) error {
 	agent.Running = true
 
 	ctx, cancelTunnel := context.WithCancel(context.Background())
-	
+
 	go ligoloStack.HandleSession(agent.Session, ctx)
 
 	// Watchdog
@@ -362,7 +362,7 @@ func StartTunnel(agent *controller.LigoloAgent, tunName string) error {
 				logrus.Infof("Closing tunnel to %s (%s)...", agent.Name, agent.SessionID)
 				cancelTunnel()
 				agent.Running = false
-				
+
 				// Clean up routes on user stop
 				if netinfo.InterfaceExist(agent.Interface) {
 					tun, err := netinfo.GetTunByName(agent.Interface)
@@ -379,14 +379,14 @@ func StartTunnel(agent *controller.LigoloAgent, tunName string) error {
 					}
 				}
 				return
-				
+
 			case <-agent.Session.CloseChan():
 				logrus.Warnf("Lost tunnel connection with agent %s (%s)!", agent.Name, agent.SessionID)
-				
+
 				// FIXED: Properly clean up the old tunnel when agent drops
 				agent.Running = false
 				cancelTunnel()
-				
+
 				// CRITICAL FIX: Remove routes from the stale interface
 				// These routes point to the old (now closed) TUN fd
 				if netinfo.InterfaceExist(agent.Interface) {
@@ -411,7 +411,7 @@ func StartTunnel(agent *controller.LigoloAgent, tunName string) error {
 						logrus.Warnf("Could not destroy interface: %v", err)
 					}
 				}
-				
+
 				if currentAgent, ok := AgentList[CurrentAgentID]; ok {
 					if currentAgent.SessionID == agent.SessionID {
 						App.SetDefaultPrompt()
@@ -653,7 +653,7 @@ func Run() {
 		},
 	})
 
-App.AddCommand(&grumble.Command{
+	App.AddCommand(&grumble.Command{
 		Name:  "ifconfig",
 		Help:  "Show agent interfaces",
 		Usage: "ifconfig",

--- a/cmd/proxy/app/daemon.go
+++ b/cmd/proxy/app/daemon.go
@@ -22,6 +22,8 @@ import (
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
 	"github.com/nicocha30/ligolo-ng/cmd/proxy/config"
+	"github.com/nicocha30/ligolo-ng/pkg/controller"
+	"github.com/nicocha30/ligolo-ng/pkg/proxy"
 	"github.com/nicocha30/ligolo-ng/pkg/proxy/netinfo"
 	"github.com/nicocha30/ligolo-ng/pkg/tlsutils"
 	"github.com/nicocha30/ligolo-ng/web"
@@ -411,6 +413,81 @@ func StartLigoloApi() {
 			CurrentAgent.CloseChan <- true
 			CurrentAgent.Running = false
 			c.JSON(http.StatusOK, gin.H{"message": "tunnel stopping"})
+		})
+
+		apiv1.POST("/relay/:id", func(c *gin.Context) {
+			type RelayRequest struct {
+				ListenAddr string
+			}
+			var relayReq RelayRequest
+			agentParam := c.Param("id")
+			agentId, err := strconv.Atoi(agentParam)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, inputError)
+				return
+			}
+			if err := c.ShouldBindJSON(&relayReq); err != nil {
+				c.JSON(http.StatusBadRequest, inputError)
+				return
+			}
+			AgentListMutex.Lock()
+			agent, ok := AgentList[agentId]
+			AgentListMutex.Unlock()
+			if !ok {
+				c.JSON(http.StatusNotFound, gin.H{"error": "invalid agent"})
+				return
+			}
+			if !agent.RelayCapable {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "agent does not support relay mode"})
+				return
+			}
+			fingerprint, err := agent.StartRelay(relayReq.ListenAddr)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			// Start notification handler
+			go agent.HandleRelayNotifications(ChainMgr, func(a *controller.LigoloAgent) error {
+				logrus.WithFields(logrus.Fields{"name": a.Name, "session": a.SessionID, "via": agent.Name}).Info("Downstream agent connected via relay")
+				return RegisterAgent(a)
+			})
+			c.JSON(http.StatusOK, gin.H{"message": "relay started", "fingerprint": fingerprint})
+		})
+
+		apiv1.DELETE("/relay/:id", func(c *gin.Context) {
+			agentParam := c.Param("id")
+			agentId, err := strconv.Atoi(agentParam)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, inputError)
+				return
+			}
+			AgentListMutex.Lock()
+			agent, ok := AgentList[agentId]
+			AgentListMutex.Unlock()
+			if !ok {
+				c.JSON(http.StatusNotFound, gin.H{"error": "invalid agent"})
+				return
+			}
+			if err := agent.StopRelay(); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"message": "relay stopped"})
+		})
+
+		apiv1.GET("/chains", func(c *gin.Context) {
+			AgentListMutex.Lock()
+			var agents []proxy.AgentInfo
+			for _, agent := range AgentList {
+				agents = append(agents, proxy.AgentInfo{
+					Name:        agent.Name,
+					SessionID:   agent.SessionID,
+					RelayActive: agent.RelayActive,
+					Alive:       agent.Alive(),
+				})
+			}
+			AgentListMutex.Unlock()
+			c.JSON(http.StatusOK, gin.H{"topology": ChainMgr.RenderTree(agents)})
 		})
 
 		apiv1.POST("/tunnel/:id", func(c *gin.Context) {

--- a/cmd/proxy/app/interfaces.go
+++ b/cmd/proxy/app/interfaces.go
@@ -119,34 +119,34 @@ func init() {
 		Run: func(c *grumble.Context) error {
 			ifName := c.Flags.String("name")
 			ifID := c.Flags.Int("id")
-			
+
 			// If neither name nor ID provided, show error
 			if ifName == "" && ifID == -1 {
 				return errors.New("please specify either --name [interface] or --id [number]")
 			}
-			
+
 			// If ID is provided, look up the interface name
 			if ifID != -1 {
 				interfaces, err := config.GetInterfaceConfigState()
 				if err != nil {
 					return err
 				}
-				
+
 				// Sort interface names to match interface_list ordering
 				var interfaceNames []string
 				for name := range interfaces {
 					interfaceNames = append(interfaceNames, name)
 				}
 				sort.Strings(interfaceNames)
-				
+
 				if ifID < 0 || ifID >= len(interfaceNames) {
 					return fmt.Errorf("invalid interface ID: %d. Use 'interface_list' to see valid IDs", ifID)
 				}
-				
+
 				ifName = interfaceNames[ifID]
 				logrus.Infof("Deleting interface #%d: %s", ifID, ifName)
 			}
-			
+
 			if config.GetInterfaceConfig(ifName) != nil {
 				if ask("Remove all interface routes and settings from config?") {
 					if err := config.DeleteInterfaceConfig(ifName); err != nil {
@@ -340,12 +340,12 @@ func init() {
 
 			var selectedIface string
 			customName := c.Flags.String("interface")
-			
+
 			// If --interface flag is provided, use it directly without prompting
 			if customName != "" {
 				logrus.Infof("Using custom interface name: %s", customName)
 				selectedIface = customName
-				
+
 				// Check if interface physically exists
 				if netinfo.InterfaceExist(selectedIface) {
 					logrus.Warnf("Interface %s already exists physically", selectedIface)
@@ -376,13 +376,13 @@ func init() {
 					if err := survey.AskOne(ifaceNamePrompt, &customIfaceName); err != nil {
 						return err
 					}
-					
+
 					var ifName string
 					if customIfaceName != "" {
 						// User provided a custom name
 						ifName = customIfaceName
 						logrus.Infof("Using custom interface name: %s", ifName)
-						
+
 						// Check if it already exists
 						if netinfo.InterfaceExist(ifName) {
 							logrus.Warnf("Interface %s already exists physically", ifName)
@@ -402,7 +402,7 @@ func init() {
 						}
 
 						ifName = codenames.Generate(rng)
-						
+
 						// Make sure the randomly generated name doesn't already exist
 						for netinfo.InterfaceExist(ifName) {
 							logrus.Warnf("Interface %s already exists, generating a new name...", ifName)
@@ -450,7 +450,7 @@ func init() {
 					}
 
 					selectedIface = ifaceMap[selectedIfaceDisplay]
-					
+
 					// Check if the selected existing interface is being used by another agent
 					for _, agent := range AgentList {
 						if agent.Running && agent.Interface == selectedIface && agent != CurrentAgent {
@@ -470,7 +470,7 @@ func init() {
 						break
 					}
 				}
-				
+
 				if !interfaceInUse {
 					logrus.Warnf("Interface %s exists but is not in use. Removing it to avoid conflicts...", selectedIface)
 					stun, err := netinfo.GetTunByName(selectedIface)

--- a/pkg/agent/handler.go
+++ b/pkg/agent/handler.go
@@ -45,7 +45,12 @@ var sessionID string
 func init() {
 	listenerConntrack = make(map[int32]net.Conn)
 	listenerMap = make(map[int32]interface{})
-	sessionID = hex.EncodeToString(uuid.NodeID())
+	// Allow overriding SessionID for testing multiple agents on the same host
+	if envID := os.Getenv("LIGOLO_SESSION_ID"); envID != "" {
+		sessionID = envID
+	} else {
+		sessionID = hex.EncodeToString(uuid.NodeID())
+	}
 }
 
 // Listener is the base class implementing listener sockets for Ligolo
@@ -184,9 +189,10 @@ func HandleConn(conn net.Conn) {
 			return
 		}
 		infoResponse := protocol.InfoReplyPacket{
-			Name:       fmt.Sprintf("%s@%s", username, hostname),
-			Interfaces: protocol.NewNetInterfaces(netifaces),
-			SessionID:  sessionID,
+			Name:         fmt.Sprintf("%s@%s", username, hostname),
+			Interfaces:   protocol.NewNetInterfaces(netifaces),
+			SessionID:    sessionID,
+			RelayCapable: true,
 		}
 
 		if err := encoder.Encode(infoResponse); err != nil {
@@ -350,6 +356,36 @@ func HandleConn(conn net.Conn) {
 
 	case *protocol.AgentKillRequestPacket:
 		os.Exit(0)
+
+	case *protocol.RelayRequestPacket:
+		relayRequest := e.Payload.(*protocol.RelayRequestPacket)
+		encoder := protocol.NewEncoder(conn)
+
+		logrus.Infof("Received relay request for %s", relayRequest.ListenAddr)
+
+		// StartRelayListener sends the RelayResponsePacket itself (with cert fingerprint)
+		if err := StartRelayListener(relayRequest.ListenAddr, conn); err != nil {
+			logrus.Errorf("Relay start failed: %v", err)
+			encoder.Encode(protocol.RelayResponsePacket{
+				Err:       true,
+				ErrString: err.Error(),
+			})
+			return
+		}
+
+		// Keep the control stream open — it's used for RelayNewConnection notifications.
+		// Block until the connection is closed by the proxy.
+		buf := make([]byte, 1)
+		conn.Read(buf)
+
+		// Control stream closed, stop relay
+		StopRelayListener()
+
+	case *protocol.RelayBridgeRequestPacket:
+		bridgeRequest := e.Payload.(*protocol.RelayBridgeRequestPacket)
+		logrus.Debugf("Received relay bridge request for connection ID %d", bridgeRequest.ConnectionID)
+
+		HandleRelayBridge(conn, bridgeRequest.ConnectionID)
 
 	}
 }

--- a/pkg/agent/relay.go
+++ b/pkg/agent/relay.go
@@ -1,0 +1,132 @@
+// Ligolo-ng
+// Copyright (C) 2025 Nicolas Chatelain (nicocha30)
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package agent
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"github.com/nicocha30/ligolo-ng/pkg/protocol"
+	"github.com/nicocha30/ligolo-ng/pkg/relay"
+	"github.com/nicocha30/ligolo-ng/pkg/tlsutils"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	relayPendingConns sync.Map // map[int32]net.Conn
+	relayConnID       atomic.Int32
+	relayListener     net.Listener
+	relayMutex        sync.Mutex
+)
+
+// StartRelayListener starts a TLS listener on the given address and notifies
+// the proxy of each downstream agent connection via the control stream.
+func StartRelayListener(listenAddr string, controlConn net.Conn) error {
+	selfcrt := tlsutils.NewSelfCert(nil)
+	crt, err := selfcrt.GetCertificate("ligolo-relay")
+	if err != nil {
+		return fmt.Errorf("relay: could not generate self-signed certificate: %v", err)
+	}
+
+	fingerprint := fmt.Sprintf("%X", sha256.Sum256(crt.Certificate[0]))
+
+	tlsCfg := &tls.Config{
+		GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return crt, nil
+		},
+	}
+
+	lis, err := tls.Listen("tcp", listenAddr, tlsCfg)
+	if err != nil {
+		return fmt.Errorf("relay: could not listen on %s: %v", listenAddr, err)
+	}
+
+	relayMutex.Lock()
+	relayListener = lis
+	relayMutex.Unlock()
+
+	// Send success response with cert fingerprint
+	encoder := protocol.NewEncoder(controlConn)
+	if err := encoder.Encode(protocol.RelayResponsePacket{
+		Err:             false,
+		CertFingerprint: fingerprint,
+	}); err != nil {
+		lis.Close()
+		return fmt.Errorf("relay: could not send response: %v", err)
+	}
+
+	logrus.Infof("Relay listener started on %s (fingerprint: %s)", listenAddr, fingerprint)
+
+	// Accept downstream agent connections
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				logrus.Debugf("Relay listener closed: %v", err)
+				return
+			}
+
+			connID := relayConnID.Add(1)
+			relayPendingConns.Store(connID, conn)
+
+			logrus.Infof("Relay: downstream agent connected from %s (ID: %d)", conn.RemoteAddr(), connID)
+
+			// Notify proxy via control stream
+			if err := encoder.Encode(protocol.RelayNewConnectionPacket{
+				ConnectionID: connID,
+				RemoteAddr:   conn.RemoteAddr().String(),
+			}); err != nil {
+				logrus.Errorf("Relay: could not notify proxy of new connection: %v", err)
+				conn.Close()
+				relayPendingConns.Delete(connID)
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// HandleRelayBridge bridges a yamux stream from the proxy to a pending downstream connection.
+func HandleRelayBridge(bridgeConn net.Conn, connectionID int32) {
+	val, ok := relayPendingConns.LoadAndDelete(connectionID)
+	if !ok {
+		logrus.Errorf("Relay bridge: no pending connection with ID %d", connectionID)
+		return
+	}
+
+	downstreamConn := val.(net.Conn)
+	logrus.Infof("Relay bridge: bridging connection ID %d to proxy", connectionID)
+
+	// Bidirectional relay between downstream agent and proxy yamux stream
+	relay.StartRelay(downstreamConn, bridgeConn)
+}
+
+// StopRelayListener stops the relay listener if one is active.
+func StopRelayListener() {
+	relayMutex.Lock()
+	defer relayMutex.Unlock()
+	if relayListener != nil {
+		relayListener.Close()
+		relayListener = nil
+		logrus.Info("Relay listener stopped")
+	}
+}

--- a/pkg/controller/agent.go
+++ b/pkg/controller/agent.go
@@ -39,8 +39,8 @@ type LigoloAgent struct {
 	RelayCapable    bool
 	RelayActive     bool
 	RelayListenAddr string
-	RelayControl    net.Conn       `json:"-"`
-	ParentAgentID   string         // SessionID of the relay agent (empty if direct)
+	RelayControl    net.Conn `json:"-"`
+	ParentAgentID   string   // SessionID of the relay agent (empty if direct)
 }
 
 func (la *LigoloAgent) Alive() bool {

--- a/pkg/controller/agent.go
+++ b/pkg/controller/agent.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/hashicorp/yamux"
 	"github.com/nicocha30/ligolo-ng/pkg/protocol"
@@ -27,14 +28,19 @@ import (
 )
 
 type LigoloAgent struct {
-	Name      string
-	Network   []protocol.NetInterface
-	Session   *yamux.Session
-	SessionID string
-	CloseChan chan bool `json:"-"`
-	Interface string
-	Running   bool
-	Listeners []*proxy.LigoloListener
+	Name            string
+	Network         []protocol.NetInterface
+	Session         *yamux.Session
+	SessionID       string
+	CloseChan       chan bool `json:"-"`
+	Interface       string
+	Running         bool
+	Listeners       []*proxy.LigoloListener
+	RelayCapable    bool
+	RelayActive     bool
+	RelayListenAddr string
+	RelayControl    net.Conn       `json:"-"`
+	ParentAgentID   string         // SessionID of the relay agent (empty if direct)
 }
 
 func (la *LigoloAgent) Alive() bool {
@@ -93,34 +99,198 @@ func (la *LigoloAgent) DeleteListener(id int) {
 	}
 }
 
+// StartRelay activates relay mode on this agent, instructing it to listen for
+// downstream agents on the given address. Returns the TLS certificate fingerprint.
+func (la *LigoloAgent) StartRelay(listenAddr string) (string, error) {
+	if la.RelayActive {
+		return "", fmt.Errorf("relay already active on %s", la.RelayListenAddr)
+	}
+	if !la.RelayCapable {
+		return "", fmt.Errorf("agent %s does not support relay mode", la.Name)
+	}
+
+	// Open a yamux stream to the agent for the relay control channel
+	controlStream, err := la.Session.Open()
+	if err != nil {
+		return "", fmt.Errorf("could not open relay control stream: %v", err)
+	}
+
+	encoder := protocol.NewEncoder(controlStream)
+	decoder := protocol.NewDecoder(controlStream)
+
+	// Send relay request
+	if err := encoder.Encode(protocol.RelayRequestPacket{
+		ListenAddr: listenAddr,
+	}); err != nil {
+		controlStream.Close()
+		return "", fmt.Errorf("could not send relay request: %v", err)
+	}
+
+	// Read response
+	if err := decoder.Decode(); err != nil {
+		controlStream.Close()
+		return "", fmt.Errorf("could not read relay response: %v", err)
+	}
+
+	resp, ok := decoder.Payload.(*protocol.RelayResponsePacket)
+	if !ok {
+		controlStream.Close()
+		return "", fmt.Errorf("unexpected response type")
+	}
+	if resp.Err {
+		controlStream.Close()
+		return "", fmt.Errorf("agent relay error: %s", resp.ErrString)
+	}
+
+	la.RelayActive = true
+	la.RelayListenAddr = listenAddr
+	la.RelayControl = controlStream
+
+	return resp.CertFingerprint, nil
+}
+
+// StopRelay deactivates relay mode by closing the control stream.
+func (la *LigoloAgent) StopRelay() error {
+	if !la.RelayActive {
+		return fmt.Errorf("relay is not active")
+	}
+	if la.RelayControl != nil {
+		la.RelayControl.Close()
+	}
+	la.RelayActive = false
+	la.RelayListenAddr = ""
+	la.RelayControl = nil
+	return nil
+}
+
+// HandleRelayNotifications listens on the relay control stream for downstream
+// agent connection notifications and bridges them back to the proxy.
+// registerFunc is called with each newly registered downstream agent.
+func (la *LigoloAgent) HandleRelayNotifications(chainMgr *proxy.ChainManager, registerFunc func(*LigoloAgent) error) {
+	decoder := protocol.NewDecoder(la.RelayControl)
+
+	for {
+		if err := decoder.Decode(); err != nil {
+			// Control stream closed — relay stopped
+			la.RelayActive = false
+			la.RelayListenAddr = ""
+			la.RelayControl = nil
+			return
+		}
+
+		notification, ok := decoder.Payload.(*protocol.RelayNewConnectionPacket)
+		if !ok {
+			continue
+		}
+
+		// Check depth limit
+		if chainMgr.WouldExceedMaxDepth(la.SessionID) {
+			fmt.Printf("WARNING: Maximum chain depth reached, rejecting downstream agent from %s\n", notification.RemoteAddr)
+			continue
+		}
+
+		// Open a new yamux stream to the relay agent for bridging
+		bridgeStream, err := la.Session.Open()
+		if err != nil {
+			fmt.Printf("ERROR: Could not open bridge stream: %v\n", err)
+			continue
+		}
+
+		// Send bridge request
+		encoder := protocol.NewEncoder(bridgeStream)
+		if err := encoder.Encode(protocol.RelayBridgeRequestPacket{
+			ConnectionID: notification.ConnectionID,
+		}); err != nil {
+			bridgeStream.Close()
+			fmt.Printf("ERROR: Could not send bridge request: %v\n", err)
+			continue
+		}
+
+		// The bridge stream is now connected to the downstream agent's raw TLS connection.
+		// Create a yamux Client session over it to talk to the downstream agent.
+		yamuxConfig := yamux.DefaultConfig()
+		yamuxConfig.EnableKeepAlive = true
+		yamuxConfig.KeepAliveInterval = 60 * time.Second
+		yamuxConfig.ConnectionWriteTimeout = 120 * time.Second
+		yamuxConfig.MaxStreamWindowSize = 16 * 1024 * 1024
+
+		downstreamSession, err := yamux.Client(bridgeStream, yamuxConfig)
+		if err != nil {
+			bridgeStream.Close()
+			fmt.Printf("ERROR: Could not create yamux session for downstream agent: %v\n", err)
+			continue
+		}
+
+		// Register the downstream agent using the normal flow
+		downstreamAgent, err := NewAgent(downstreamSession)
+		if err != nil {
+			downstreamSession.Close()
+			fmt.Printf("ERROR: Could not register downstream agent: %v\n", err)
+			continue
+		}
+
+		// Check for circular chains
+		if chainMgr.IsCircular(la.SessionID, downstreamAgent.SessionID) {
+			downstreamSession.Close()
+			fmt.Printf("WARNING: Circular chain detected, rejecting agent %s\n", downstreamAgent.SessionID)
+			continue
+		}
+
+		downstreamAgent.ParentAgentID = la.SessionID
+		chainMgr.AddLink(la.SessionID, downstreamAgent.SessionID)
+
+		fmt.Printf("INFO: Downstream agent joined via %s: %s (%s)\n", la.Name, downstreamAgent.Name, notification.RemoteAddr)
+
+		if err := registerFunc(downstreamAgent); err != nil {
+			fmt.Printf("ERROR: Could not register downstream agent: %v\n", err)
+		}
+	}
+}
+
 func (la *LigoloAgent) String() string {
 	raddr := "[Offline]"
 	if la.Session != nil {
 		raddr = la.Session.RemoteAddr().String()
 	}
 
-	return fmt.Sprintf("%s - %s - %s", la.Name, raddr, la.SessionID)
+	suffix := ""
+	if la.ParentAgentID != "" {
+		suffix = fmt.Sprintf(" (via %s)", la.ParentAgentID)
+	}
+	if la.RelayActive {
+		suffix += " [relay]"
+	}
+
+	return fmt.Sprintf("%s - %s - %s%s", la.Name, raddr, la.SessionID, suffix)
 }
 
 func (la *LigoloAgent) MarshalJSON() ([]byte, error) {
 	type Session struct {
-		Name       string
-		Network    []protocol.NetInterface
-		SessionID  string
-		RemoteAddr string
-		Interface  string
-		Running    bool
-		Listeners  []*proxy.LigoloListener
+		Name            string
+		Network         []protocol.NetInterface
+		SessionID       string
+		RemoteAddr      string
+		Interface       string
+		Running         bool
+		Listeners       []*proxy.LigoloListener
+		RelayCapable    bool
+		RelayActive     bool
+		RelayListenAddr string
+		ParentAgentID   string
 	}
 
 	return json.Marshal(Session{
-		Name:       la.Name,
-		Running:    la.Running,
-		Listeners:  la.Listeners,
-		Network:    la.Network,
-		Interface:  la.Interface,
-		SessionID:  la.SessionID,
-		RemoteAddr: la.Session.RemoteAddr().String(),
+		Name:            la.Name,
+		Running:         la.Running,
+		Listeners:       la.Listeners,
+		Network:         la.Network,
+		Interface:       la.Interface,
+		SessionID:       la.SessionID,
+		RemoteAddr:      la.Session.RemoteAddr().String(),
+		RelayCapable:    la.RelayCapable,
+		RelayActive:     la.RelayActive,
+		RelayListenAddr: la.RelayListenAddr,
+		ParentAgentID:   la.ParentAgentID,
 	})
 }
 
@@ -146,10 +316,11 @@ func NewAgent(session *yamux.Session) (*LigoloAgent, error) {
 	reply := protocolDecoder.Payload.(*protocol.InfoReplyPacket)
 
 	return &LigoloAgent{
-		Name:      reply.Name,
-		Network:   reply.Interfaces,
-		Session:   session,
-		SessionID: reply.SessionID,
-		CloseChan: make(chan bool),
+		Name:         reply.Name,
+		Network:      reply.Interfaces,
+		Session:      session,
+		SessionID:    reply.SessionID,
+		CloseChan:    make(chan bool),
+		RelayCapable: reply.RelayCapable,
 	}, nil
 }

--- a/pkg/protocol/decoder.go
+++ b/pkg/protocol/decoder.go
@@ -67,6 +67,14 @@ func interfaceFromPayloadType(payloadType uint8) (interface{}, error) {
 		return &AgentKillRequestPacket{}, nil
 	case MessageListenerSocketConnectionReady:
 		return &ListenerSocketConnectionReady{}, nil
+	case MessageRelayRequest:
+		return &RelayRequestPacket{}, nil
+	case MessageRelayResponse:
+		return &RelayResponsePacket{}, nil
+	case MessageRelayNewConnection:
+		return &RelayNewConnectionPacket{}, nil
+	case MessageRelayBridgeRequest:
+		return &RelayBridgeRequestPacket{}, nil
 	default:
 		return nil, fmt.Errorf("decode called for unknown payload type: %d", payloadType)
 	}

--- a/pkg/protocol/encoder.go
+++ b/pkg/protocol/encoder.go
@@ -66,6 +66,14 @@ func payloadTypeFromInterface(payload interface{}) (uint8, error) {
 		return MessageAgentKillRequest, nil
 	case ListenerSocketConnectionReady:
 		return MessageListenerSocketConnectionReady, nil
+	case RelayRequestPacket:
+		return MessageRelayRequest, nil
+	case RelayResponsePacket:
+		return MessageRelayResponse, nil
+	case RelayNewConnectionPacket:
+		return MessageRelayNewConnection, nil
+	case RelayBridgeRequestPacket:
+		return MessageRelayBridgeRequest, nil
 	default:
 		return 0, fmt.Errorf("payloadTypeFromInterface called for unknown payload type: %v", payload)
 	}

--- a/pkg/protocol/packets.go
+++ b/pkg/protocol/packets.go
@@ -44,6 +44,10 @@ const (
 	MessageListenerCloseResponse
 	MessageAgentKillRequest
 	MessageListenerSocketConnectionReady
+	MessageRelayRequest
+	MessageRelayResponse
+	MessageRelayNewConnection
+	MessageRelayBridgeRequest
 )
 
 const (
@@ -62,9 +66,10 @@ type InfoRequestPacket struct {
 
 // InfoReplyPacket contains the Name of the agent and the network interfaces configuration
 type InfoReplyPacket struct {
-	Name       string
-	Interfaces []NetInterface
-	SessionID  string
+	Name         string
+	Interfaces   []NetInterface
+	SessionID    string
+	RelayCapable bool
 }
 
 // ListenerSockRequestPacket is used by the proxy when relaying a listener socket
@@ -202,3 +207,26 @@ type HostPingResponsePacket struct {
 
 // AgentKillRequestPacket is sent by the proxy to terminate an agent
 type AgentKillRequestPacket struct{}
+
+// RelayRequestPacket is sent by the proxy to instruct an agent to start a relay listener
+type RelayRequestPacket struct {
+	ListenAddr string
+}
+
+// RelayResponsePacket is the response to RelayRequestPacket
+type RelayResponsePacket struct {
+	Err             bool
+	ErrString       string
+	CertFingerprint string
+}
+
+// RelayNewConnectionPacket is sent by the agent on the relay control stream when a downstream agent connects
+type RelayNewConnectionPacket struct {
+	ConnectionID int32
+	RemoteAddr   string
+}
+
+// RelayBridgeRequestPacket is sent by the proxy to the agent to bridge a yamux stream to a pending downstream connection
+type RelayBridgeRequestPacket struct {
+	ConnectionID int32
+}

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -49,6 +49,95 @@ func TestEncodeDecode(t *testing.T) {
 
 }
 
+func TestRelayPackets(t *testing.T) {
+	tests := []struct {
+		name    string
+		packet  interface{}
+		checker func(interface{}) bool
+	}{
+		{
+			name:   "RelayRequest",
+			packet: RelayRequestPacket{ListenAddr: "0.0.0.0:11602"},
+			checker: func(p interface{}) bool {
+				pkt := p.(*RelayRequestPacket)
+				return pkt.ListenAddr == "0.0.0.0:11602"
+			},
+		},
+		{
+			name:   "RelayResponse",
+			packet: RelayResponsePacket{Err: false, CertFingerprint: "AABBCCDD"},
+			checker: func(p interface{}) bool {
+				pkt := p.(*RelayResponsePacket)
+				return !pkt.Err && pkt.CertFingerprint == "AABBCCDD"
+			},
+		},
+		{
+			name:   "RelayResponseError",
+			packet: RelayResponsePacket{Err: true, ErrString: "bind failed"},
+			checker: func(p interface{}) bool {
+				pkt := p.(*RelayResponsePacket)
+				return pkt.Err && pkt.ErrString == "bind failed"
+			},
+		},
+		{
+			name:   "RelayNewConnection",
+			packet: RelayNewConnectionPacket{ConnectionID: 42, RemoteAddr: "10.0.0.5:54321"},
+			checker: func(p interface{}) bool {
+				pkt := p.(*RelayNewConnectionPacket)
+				return pkt.ConnectionID == 42 && pkt.RemoteAddr == "10.0.0.5:54321"
+			},
+		},
+		{
+			name:   "RelayBridgeRequest",
+			packet: RelayBridgeRequestPacket{ConnectionID: 42},
+			checker: func(p interface{}) bool {
+				pkt := p.(*RelayBridgeRequestPacket)
+				return pkt.ConnectionID == 42
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+
+			enc := NewEncoder(&buffer)
+			if err := enc.Encode(tt.packet); err != nil {
+				t.Fatalf("encode error: %v", err)
+			}
+
+			dec := NewDecoder(&buffer)
+			if err := dec.Decode(); err != nil {
+				t.Fatalf("decode error: %v", err)
+			}
+
+			if !tt.checker(dec.Payload) {
+				t.Fatalf("decoded packet does not match: %+v", dec.Payload)
+			}
+		})
+	}
+}
+
+func TestInfoReplyRelayCapable(t *testing.T) {
+	var buffer bytes.Buffer
+
+	packet := InfoReplyPacket{Name: "test@host", SessionID: "abc123", RelayCapable: true}
+	enc := NewEncoder(&buffer)
+	if err := enc.Encode(packet); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := NewDecoder(&buffer)
+	if err := dec.Decode(); err != nil {
+		t.Fatal(err)
+	}
+
+	reply := dec.Payload.(*InfoReplyPacket)
+	if reply.Name != "test@host" || !reply.RelayCapable || reply.SessionID != "abc123" {
+		t.Fatalf("unexpected packet: %+v", reply)
+	}
+}
+
 func BenchmarkEncodeDecode(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var buffer bytes.Buffer

--- a/pkg/proxy/chain.go
+++ b/pkg/proxy/chain.go
@@ -1,0 +1,236 @@
+// Ligolo-ng
+// Copyright (C) 2025 Nicolas Chatelain (nicocha30)
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package proxy
+
+import (
+	"fmt"
+	"sync"
+)
+
+// MaxChainDepth is the maximum number of hops allowed in a relay chain.
+const MaxChainDepth = 5
+
+// ChainManager tracks the relay topology between agents.
+type ChainManager struct {
+	mu    sync.Mutex
+	links map[string]string // downstream SessionID -> relay agent SessionID
+}
+
+// NewChainManager creates a new ChainManager.
+func NewChainManager() *ChainManager {
+	return &ChainManager{
+		links: make(map[string]string),
+	}
+}
+
+// AddLink records that a downstream agent is connected through a relay agent.
+func (cm *ChainManager) AddLink(relaySessionID, downstreamSessionID string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.links[downstreamSessionID] = relaySessionID
+}
+
+// RemoveAgent removes an agent from the chain tracking.
+func (cm *ChainManager) RemoveAgent(sessionID string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	delete(cm.links, sessionID)
+}
+
+// GetParentSessionID returns the relay agent's SessionID for a downstream agent,
+// or empty string if the agent is directly connected.
+func (cm *ChainManager) GetParentSessionID(sessionID string) string {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return cm.links[sessionID]
+}
+
+// GetChainPath returns the ordered list of SessionIDs from the proxy to the given agent.
+// The last element is the agent itself. Returns nil if the agent is directly connected.
+func (cm *ChainManager) GetChainPath(sessionID string) []string {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	var path []string
+	current := sessionID
+	visited := make(map[string]bool)
+
+	for {
+		if visited[current] {
+			// Circular chain detected, break
+			break
+		}
+		visited[current] = true
+		path = append([]string{current}, path...)
+
+		parent, ok := cm.links[current]
+		if !ok {
+			break
+		}
+		current = parent
+	}
+
+	if len(path) <= 1 {
+		return nil // Direct connection
+	}
+	return path
+}
+
+// GetChainDepth returns the number of hops from the proxy to the given agent.
+// Direct connections return 0.
+func (cm *ChainManager) GetChainDepth(sessionID string) int {
+	path := cm.GetChainPath(sessionID)
+	if path == nil {
+		return 0
+	}
+	return len(path) - 1
+}
+
+// WouldExceedMaxDepth checks if adding a downstream agent through the given
+// relay agent would exceed the maximum chain depth.
+func (cm *ChainManager) WouldExceedMaxDepth(relaySessionID string) bool {
+	return cm.GetChainDepth(relaySessionID)+1 >= MaxChainDepth
+}
+
+// IsCircular checks if adding a link from relaySessionID to downstreamSessionID
+// would create a circular chain. It walks up the chain from the relay agent's
+// parent to see if the downstream agent is already an ancestor. This only
+// detects actual graph cycles, not duplicate SessionIDs on the same machine.
+func (cm *ChainManager) IsCircular(relaySessionID, downstreamSessionID string) bool {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	// Walk up from the relay agent's parent (not the relay itself)
+	current, ok := cm.links[relaySessionID]
+	if !ok {
+		return false // relay is directly connected, no cycle possible
+	}
+
+	visited := make(map[string]bool)
+	for {
+		if current == downstreamSessionID {
+			return true
+		}
+		if visited[current] {
+			break
+		}
+		visited[current] = true
+		parent, ok := cm.links[current]
+		if !ok {
+			break
+		}
+		current = parent
+	}
+	return false
+}
+
+// GetDownstreamSessionIDs returns all SessionIDs of agents connected through the given relay.
+func (cm *ChainManager) GetDownstreamSessionIDs(relaySessionID string) []string {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	var downstream []string
+	for child, parent := range cm.links {
+		if parent == relaySessionID {
+			downstream = append(downstream, child)
+		}
+	}
+	return downstream
+}
+
+// AgentInfo is a minimal interface for rendering the chain tree.
+type AgentInfo struct {
+	Name        string
+	SessionID   string
+	RelayActive bool
+	Alive       bool
+}
+
+// RenderTree returns a string representation of the chain topology tree.
+func (cm *ChainManager) RenderTree(agents []AgentInfo) string {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	// Find root agents (directly connected)
+	var roots []AgentInfo
+	agentMap := make(map[string]AgentInfo)
+	for _, a := range agents {
+		agentMap[a.SessionID] = a
+		if _, hasParent := cm.links[a.SessionID]; !hasParent {
+			roots = append(roots, a)
+		}
+	}
+
+	if len(roots) == 0 {
+		return "No agents connected."
+	}
+
+	result := "Chain topology:\n  Proxy\n"
+	for i, root := range roots {
+		isLast := i == len(roots)-1
+		result += cm.renderNode(root, agentMap, "  ", isLast)
+	}
+	return result
+}
+
+func (cm *ChainManager) renderNode(agent AgentInfo, agentMap map[string]AgentInfo, prefix string, isLast bool) string {
+	connector := "├── "
+	childPrefix := prefix + "│   "
+	if isLast {
+		connector = "└── "
+		childPrefix = prefix + "    "
+	}
+
+	status := "[direct]"
+	if _, hasParent := cm.links[agent.SessionID]; hasParent {
+		depth := 0
+		current := agent.SessionID
+		for {
+			parent, ok := cm.links[current]
+			if !ok {
+				break
+			}
+			depth++
+			current = parent
+		}
+		status = fmt.Sprintf("[%d hop(s)]", depth)
+	}
+
+	relayInfo := ""
+	if agent.RelayActive {
+		relayInfo = " (relay: active)"
+	}
+
+	result := fmt.Sprintf("%s%s%s %s%s\n", prefix, connector, agent.Name, status, relayInfo)
+
+	// Find children
+	var children []AgentInfo
+	for child, parent := range cm.links {
+		if parent == agent.SessionID {
+			if a, ok := agentMap[child]; ok {
+				children = append(children, a)
+			}
+		}
+	}
+
+	for i, child := range children {
+		isLastChild := i == len(children)-1
+		result += cm.renderNode(child, agentMap, childPrefix, isLastChild)
+	}
+
+	return result
+}


### PR DESCRIPTION
## Summary

Adds relay mode to agents, enabling multi-hop pivoting through segmented networks where downstream agents cannot reach the proxy directly.

```
Proxy <--yamux/TLS--> Agent A (relay) <--TLS--> Agent B --> Target Network
```

- Agents can act as lightweight TLS relay listeners for downstream agents
- Each hop uses raw `io.Copy` bridging — no nested yamux, minimal overhead
- The proxy sees all agents as direct connections, so tunnels, listeners, kill, and session recovery all work unchanged
- Maximum chain depth of 5 hops with circular chain detection

## Changes

**Protocol (`pkg/protocol/`):**
- 4 new message types: `RelayRequest`, `RelayResponse`, `RelayNewConnection`, `RelayBridgeRequest`
- `RelayCapable` field added to `InfoReplyPacket`
- Tests for all new packet types

**Agent (`pkg/agent/`):**
- New `relay.go`: TLS relay listener with self-signed cert generation, pending connection tracking, and bridge handling
- `handler.go`: Two new `HandleConn` cases for relay request and bridge request
- `LIGOLO_SESSION_ID` env var for testing multiple agents on one host

**Proxy (`pkg/proxy/`, `pkg/controller/`, `cmd/proxy/`):**
- New `chain.go`: `ChainManager` for topology tracking, depth limits, cycle detection, and tree rendering
- `agent.go`: `StartRelay()`, `StopRelay()`, `HandleRelayNotifications()` methods; relay fields on `LigoloAgent`
- CLI commands: `relay_start`, `relay_stop`, `chain_list`
- API endpoints: `POST/DELETE /api/v1/relay/:id`, `GET /api/v1/chains`
- Relay recovery in `RegisterAgent()` — relay listeners restart automatically on agent reconnect

## Usage

```bash
# In proxy CLI, select an agent and start relay:
ligolo-ng » session
[Agent: user@DMZ] » relay_start --addr 0.0.0.0:11602

# On a host in Agent A's network:
./agent -connect <AgentA_IP>:11602 -ignore-cert

# Agent B auto-registers. View topology:
ligolo-ng » chain_list
```

## Test plan

- [x] `go fmt` / `go vet` clean
- [x] Protocol encode/decode tests pass for all new message types
- [x] Cross-compilation verified: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64, freebsd/amd64
- [x] End-to-end local test: proxy + Agent A (relay) + Agent B through relay, verified via API that both agents register and chain topology is correct
- [x] Backward compatible — existing agents without relay work unchanged (`RelayCapable` defaults to false for old agents)