### PR TITLE
Add ICMP Port Unreachable for UDP scan acceleration

### DIFF
--- a/pkg/proxy/netstack/handlers.go
+++ b/pkg/proxy/netstack/handlers.go
@@ -176,6 +176,10 @@ func HandlePacket(nstack *stack.Stack, localConn TunConn, yamuxConn *yamux.Sessi
 			}
 
 		}()
+	} else if localConn.IsUDP() && reply.Reset {
+		// Agent got ECONNREFUSED on UDP — send ICMP Port Unreachable back
+		// so scanners like nmap can detect closed ports instantly.
+		SendICMPPortUnreachable(nstack, localConn.GetUDP().EndpointID)
 	} else {
 		localConn.Terminate(reply.Reset)
 	}

--- a/pkg/proxy/netstack/icmp.go
+++ b/pkg/proxy/netstack/icmp.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 
+	"encoding/binary"
 	"github.com/nicocha30/gvisor-ligolo/pkg/buffer"
 	"github.com/nicocha30/gvisor-ligolo/pkg/tcpip"
 	"github.com/nicocha30/gvisor-ligolo/pkg/tcpip/checksum"
@@ -193,4 +194,90 @@ func ProcessICMP(nstack *stack.Stack, pkt stack.PacketBufferPtr) {
 			return
 		}
 	}
+}
+
+// SendICMPPortUnreachable generates an ICMP Destination Unreachable (Type 3, Code 3)
+// packet and injects it back into the TUN interface. This is sent when a UDP connection
+// to a remote port is refused (ECONNREFUSED), allowing tools like nmap to detect closed
+// UDP ports instantly instead of waiting for a timeout.
+//
+// Per RFC 792, the ICMP error payload contains the original IP header + first 8 bytes
+// of the original datagram (the UDP header), which lets the scanner correlate the
+// error with its probe.
+func SendICMPPortUnreachable(nstack *stack.Stack, endpointID stack.TransportEndpointID) {
+	// The endpointID fields from the perspective of the netstack forwarder:
+	//   LocalAddress/LocalPort   = the destination (target host:port)
+	//   RemoteAddress/RemotePort = the source (scanner host:port)
+	//
+	// The ICMP error goes FROM the target back TO the scanner.
+	srcAddr := endpointID.LocalAddress
+	dstAddr := endpointID.RemoteAddress
+
+	r, err := nstack.FindRoute(1, srcAddr, dstAddr, ipv4.ProtocolNumber, false)
+	if err != nil {
+		logrus.Debugf("SendICMPPortUnreachable: could not find route: %v", err)
+		return
+	}
+	defer r.Release()
+
+	// Build the "original IP header + first 8 bytes of datagram" payload.
+	// This is what goes inside the ICMP error message per RFC 792.
+	//
+	// Original IP header (20 bytes, no options):
+	origIPHdr := make([]byte, header.IPv4MinimumSize)
+	ip := header.IPv4(origIPHdr)
+	ip.Encode(&header.IPv4Fields{
+		TotalLength: header.IPv4MinimumSize + header.UDPMinimumSize,
+		TTL:         64,
+		Protocol:    uint8(header.UDPProtocolNumber),
+		SrcAddr:     dstAddr, // original packet was FROM scanner
+		DstAddr:     srcAddr, // original packet was TO target
+	})
+	ip.SetChecksum(^ip.CalculateChecksum())
+
+	// First 8 bytes of original datagram = UDP header (src port, dst port, length, checksum)
+	origUDPHdr := make([]byte, header.UDPMinimumSize)
+	binary.BigEndian.PutUint16(origUDPHdr[0:2], endpointID.RemotePort) // original src port
+	binary.BigEndian.PutUint16(origUDPHdr[2:4], endpointID.LocalPort)  // original dst port
+	binary.BigEndian.PutUint16(origUDPHdr[4:6], header.UDPMinimumSize) // length
+	// checksum left as 0 (optional for UDP in IPv4)
+
+	// Build ICMP Destination Unreachable message:
+	// [Type=3][Code=3][Checksum][Unused/0][Original IP Hdr + 8 bytes]
+	icmpLen := header.ICMPv4MinimumSize + len(origIPHdr) + len(origUDPHdr)
+	icmpHdr := make(header.ICMPv4, icmpLen)
+	icmpHdr.SetType(header.ICMPv4DstUnreachable)
+	icmpHdr.SetCode(header.ICMPv4PortUnreachable)
+	copy(icmpHdr[header.ICMPv4MinimumSize:], origIPHdr)
+	copy(icmpHdr[header.ICMPv4MinimumSize+len(origIPHdr):], origUDPHdr)
+	icmpHdr.SetChecksum(0)
+	icmpHdr.SetChecksum(^checksum.Checksum(icmpHdr, 0))
+
+	// Build outer IP header for the ICMP error packet
+	outerIPHdr := make(header.IPv4, header.IPv4MinimumSize)
+	outerIPHdr.Encode(&header.IPv4Fields{
+		TotalLength: uint16(header.IPv4MinimumSize + icmpLen),
+		TTL:         r.DefaultTTL(),
+		Protocol:    uint8(header.ICMPv4ProtocolNumber),
+		SrcAddr:     r.LocalAddress(),
+		DstAddr:     r.RemoteAddress(),
+	})
+	outerIPHdr.SetChecksum(^outerIPHdr.CalculateChecksum())
+
+	// Assemble full packet and inject into the network stack
+	pktBuf := buffer.MakeWithData(outerIPHdr)
+	pktBuf.Append(buffer.NewViewWithData(icmpHdr))
+	replyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		ReserveHeaderBytes: int(r.MaxHeaderLength()),
+		Payload:            pktBuf,
+	})
+	replyPkt.TransportProtocolNumber = header.ICMPv4ProtocolNumber
+
+	if err := r.WriteHeaderIncludedPacket(replyPkt); err != nil {
+		logrus.Debugf("SendICMPPortUnreachable: write error: %v", err)
+		return
+	}
+
+	logrus.Debugf("Sent ICMP Port Unreachable for %s:%d -> %s:%d",
+		dstAddr, endpointID.RemotePort, srcAddr, endpointID.LocalPort)
 }


### PR DESCRIPTION
## Summary

Implements the first item from the README TODO: ICMP error messages to speed up UDP scans.

When a UDP connection is refused on the agent side (`ECONNREFUSED`), the proxy now generates an ICMP Destination Unreachable (Type 3, Code 3 = Port Unreachable) packet and injects it back into the TUN interface. This lets scanners like nmap detect closed UDP ports instantly instead of waiting for a timeout.

**Before:** Every closed UDP port = full timeout wait. A 100-port UDP scan takes minutes.
**After:** Closed ports return immediately as "closed". Only open/filtered ports wait for timeout.

## What was wrong

The `Terminate()` method in `stack.go` is a no-op for UDP — it only handles TCP. So when the agent reported a refused UDP connection via `ConnectResponsePacket{Reset: true}`, the proxy silently dropped it. The scanner never got any response back.

## Changes

**`pkg/proxy/netstack/icmp.go`** — New `SendICMPPortUnreachable()` function (~60 lines):
- Builds an RFC 792 ICMP Type 3/Code 3 packet
- Includes original IP header + 8-byte UDP header in the payload (so nmap can correlate the response)
- Injects via `route.WriteHeaderIncludedPacket()` (same pattern as existing `ProcessICMP()` for Echo Reply)

**`pkg/proxy/netstack/handlers.go`** — 3-line change:
- When UDP `ConnectResponse` has `Reset=true`, call `SendICMPPortUnreachable()` instead of the no-op `Terminate()`

No protocol changes. No agent changes. Fully backward compatible.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet` clean on netstack package
- [x] `go fmt` clean
- [x] Cross-compilation: linux/amd64, linux/arm64, windows/amd64, darwin/arm64, freebsd/amd64
- [x] Existing protocol tests pass
- [ ] Manual test: `nmap -sU` through tunnel should show closed ports as "closed" instead of "open|filtered"