### PR TITLE
fix: panic when -config is given an absolute or out-of-search-path file

### DIFF
--- a/cmd/proxy/config/config.go
+++ b/cmd/proxy/config/config.go
@@ -169,32 +169,52 @@ func ask(question string) bool {
 
 func InitConfig(configFile string) {
 	var firstStart bool
-	if configFile == "" {
-		configFile = "ligolo-ng.yaml"
-	} else {
+	if configFile != "" {
+		// Explicit path: verify it exists and use SetConfigFile so that
+		// both ReadInConfig and WriteConfig operate on the same path.
+		// Using SetConfigName with a full path works accidentally on read
+		// but causes WriteConfig to panic because it searches only the
+		// registered AddConfigPath directories for the stem.
 		if _, err := os.Stat(configFile); errors.Is(err, os.ErrNotExist) {
 			logrus.Fatal("config file does not exist")
 		}
+		Config.SetConfigFile(configFile)
+	} else {
+		// No explicit path — search standard locations.
+		Config.SetConfigName("ligolo-ng")
+		Config.SetConfigType("yaml")
+		Config.AddConfigPath(".")
+		Config.AddConfigPath(os.ExpandEnv("$HOME/.ligolo-proxy"))
+		Config.AddConfigPath("/etc/ligolo-proxy")
 	}
-	Config.SetConfigName(configFile)
-	Config.SetConfigType("yaml")
-	Config.AddConfigPath(".")
-	Config.AddConfigPath("$HOME/.ligolo-proxy")
-	Config.AddConfigPath("/etc/ligolo-proxy")
 
-	logrus.Infof("Loading configuration file %s", configFile)
+	if configFile != "" {
+		logrus.Infof("Loading configuration file %s", configFile)
+	} else {
+		logrus.Info("Searching for configuration file in standard paths")
+	}
 	if err := Config.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			if configFile != "" {
+				logrus.Fatalf("config file disappeared after validation: %s", configFile)
+			}
 			logrus.Warn("daemon configuration file not found. Creating a new one...")
-			f, err := os.Create(configFile)
+			// Create the file in ~/.ligolo-proxy so WriteConfig always has a
+			// known path regardless of the working directory.
+			defaultDir := os.ExpandEnv("$HOME/.ligolo-proxy")
+			defaultPath := defaultDir + "/ligolo-ng.yaml"
+			if err := os.MkdirAll(defaultDir, 0700); err != nil {
+				panic(err)
+			}
+			f, err := os.Create(defaultPath)
 			firstStart = true
 			if err != nil {
 				panic(err)
 			}
-			err = f.Close()
-			if err != nil {
+			if err = f.Close(); err != nil {
 				panic(err)
 			}
+			Config.SetConfigFile(defaultPath)
 		} else {
 			panic(err)
 		}


### PR DESCRIPTION
## Summary

Passing an absolute (or otherwise explicit) path to `-config` causes a panic on
startup whenever the config file needs to be written — including on first run.

```
panic: unable to write config file: Config File "/home/user/Tools/Ligolo/ligolo-ng.yaml"
Not Found in "[/home/user/Desktop/HTB/project /home/user/.ligolo-proxy /etc/ligolo-proxy]"
```

## Root cause

`InitConfig` was calling `Config.SetConfigName(configFile)` regardless of whether
`configFile` was a bare filename or a full path. This is the wrong Viper API for
explicit paths:

- `SetConfigName` sets a filename **stem** that Viper searches for across its
  registered `AddConfigPath` directories. Passing a full path here works
  accidentally on *read* (Viper is lenient), but `WriteConfig` strictly searches
  only the registered paths and fails with `ConfigFileNotFoundError`.
- `SetConfigFile` sets an **exact path** used for both reads and writes — the
  correct API when the user has given an explicit location.

There was also a secondary issue: when no config file is found and one is created
fresh, it was created at the bare name `"ligolo-ng.yaml"` (relative to CWD) but
Viper was not told the exact path, so `WriteConfig` would again fail to locate it.

## Changes

**`cmd/proxy/config/config.go`**

- When `-config` is supplied, use `Config.SetConfigFile()` instead of
  `Config.SetConfigName()` so that `WriteConfig()` writes back to the same path.
- When no `-config` is supplied and no existing config is found, create the new
  file explicitly at `$HOME/.ligolo-proxy/ligolo-ng.yaml` (creating the directory
  if needed), then call `Config.SetConfigFile()` with that path before
  `WriteConfig()` runs.
- Guard the `ConfigFileNotFoundError` branch: if an explicit `-config` path was
  given but the file disappears between the `os.Stat` check and `ReadInConfig`,
  fatal cleanly instead of silently creating a default file in the wrong location.
- Fix the startup log message to not print an empty string when no `-config` is passed.
- Fix `SetConfigName("ligolo-ng.yaml")` → `SetConfigName("ligolo-ng")`: the name
  passed to `SetConfigName` should not include the extension, since the type is
  registered separately via `SetConfigType`.
- Expand `$HOME` in `AddConfigPath` via `os.ExpandEnv` (Viper does not shell-expand).

## Behaviour before and after

| Scenario | Before | After |
|---|---|---|
| `-config /absolute/path/ligolo-ng.yaml` | panic on `WriteConfig` | works correctly |
| `-config ../../relative/ligolo-ng.yaml` | worked by accident (CWD happened to be a search path) | works correctly |
| No `-config`, existing file in search path | works | works (unchanged) |
| No `-config`, no existing file | creates `ligolo-ng.yaml` in CWD, may fail `WriteConfig` | creates `~/.ligolo-proxy/ligolo-ng.yaml`, always succeeds |

## Testing

Reproduce the panic with:
```bash
cd ~/some/other/directory
/path/to/proxy -selfcert -config /absolute/path/to/ligolo-ng.yaml
```
After this fix, the proxy starts cleanly regardless of working directory or
whether the path is absolute or relative.
