### PR TITLE
fix: reverse UDP listener relays return traffic (#147)

### DIFF
--- a/pkg/agent/handler.go
+++ b/pkg/agent/handler.go
@@ -279,7 +279,7 @@ func HandleConn(conn net.Conn) {
 				logrus.Error(err)
 			}
 			go func() {
-				err := relay.StartRelay(conn, udplistener)
+				err := relay.StartUDPListenerRelay(conn, udplistener.UDPConn)
 				if err != nil {
 					logrus.Error(err)
 				}

--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -19,7 +19,12 @@ package relay
 import (
 	"io"
 	"net"
+	"sync"
 )
+
+// maxUDPDatagramSize is large enough to hold the biggest possible UDP payload,
+// so ReadFromUDP never truncates a datagram.
+const maxUDPDatagramSize = 65535
 
 func relay(src net.Conn, dst net.Conn, stop chan error, closeOnError bool) {
 	_, err := io.Copy(dst, src)
@@ -54,4 +59,72 @@ func StartPacketRelay(src net.Conn, dst net.Conn) error {
 	case err := <-stop:
 		return err
 	}
+}
+
+// StartUDPListenerRelay relays datagrams between a reverse UDP listener
+// (udpConn, an unconnected socket from net.ListenUDP) and the tunnel back to
+// the proxy. Unlike StartRelay, it cannot pump raw bytes with io.Copy: the
+// listening socket has no fixed peer, so Write always fails and return traffic
+// must be sent with WriteToUDP. The address of the most recent client is
+// tracked from ReadFromUDP so replies coming back through the tunnel reach it.
+//
+// Return traffic is routed to the most recently seen client, which serves the
+// common single-client case; the listening socket carries no per-client
+// demultiplexing, so concurrent clients would share the return path.
+func StartUDPListenerRelay(tunnel net.Conn, udpConn *net.UDPConn) error {
+	stop := make(chan error, 2)
+
+	var mu sync.Mutex
+	var clientAddr *net.UDPAddr
+
+	// Listener -> tunnel: forward client datagrams to the proxy, remembering
+	// where each one came from so return traffic can be addressed back.
+	go func() {
+		buf := make([]byte, maxUDPDatagramSize)
+		for {
+			n, addr, err := udpConn.ReadFromUDP(buf)
+			if n > 0 {
+				mu.Lock()
+				clientAddr = addr
+				mu.Unlock()
+				if _, werr := tunnel.Write(buf[:n]); werr != nil {
+					stop <- werr
+					return
+				}
+			}
+			if err != nil {
+				stop <- err
+				return
+			}
+		}
+	}()
+
+	// Tunnel -> listener: deliver replies to the last known client using
+	// WriteToUDP, since the listening socket is not connected to a peer.
+	go func() {
+		buf := make([]byte, maxUDPDatagramSize)
+		for {
+			n, err := tunnel.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				addr := clientAddr
+				mu.Unlock()
+				if addr != nil {
+					if _, werr := udpConn.WriteToUDP(buf[:n], addr); werr != nil {
+						stop <- werr
+						return
+					}
+				}
+			}
+			if err != nil {
+				stop <- err
+				return
+			}
+		}
+	}()
+
+	err := <-stop
+	udpConn.Close()
+	tunnel.Close()
+	return err
 }

--- a/pkg/relay/relay_test.go
+++ b/pkg/relay/relay_test.go
@@ -1,0 +1,89 @@
+// Ligolo-ng
+// Copyright (C) 2025 Nicolas Chatelain (nicocha30)
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package relay
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestStartUDPListenerRelayReturnTraffic reproduces
+// https://github.com/nicocha30/ligolo-ng/issues/147: a reverse UDP listener
+// must keep relaying after the redirect target replies. The agent listens on
+// an unconnected UDP socket (net.ListenUDP) and relays datagrams over the
+// tunnel. The previous implementation pumped raw bytes with io.Copy, so the
+// return path called Write on the unconnected socket, which always fails and
+// tore the whole listener down on the first reply.
+func TestStartUDPListenerRelayReturnTraffic(t *testing.T) {
+	// Agent-side UDP listener, exactly as NewUDPListener creates it.
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	defer udpConn.Close()
+	listenerAddr := udpConn.LocalAddr().(*net.UDPAddr)
+
+	// net.Pipe stands in for the yamux tunnel back to the proxy.
+	proxySide, tunnelSide := net.Pipe()
+	defer proxySide.Close()
+	defer tunnelSide.Close()
+
+	go StartUDPListenerRelay(tunnelSide, udpConn)
+
+	// A UDP client reaches the agent listener and sends a datagram.
+	client, err := net.DialUDP("udp", nil, listenerAddr)
+	if err != nil {
+		t.Fatalf("DialUDP: %v", err)
+	}
+	defer client.Close()
+
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	// Forward direction: the datagram must reach the proxy side of the tunnel.
+	if err := proxySide.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	buf := make([]byte, 1024)
+	n, err := proxySide.Read(buf)
+	if err != nil {
+		t.Fatalf("reading forwarded datagram from tunnel: %v", err)
+	}
+	if got := buf[:n]; !bytes.Equal(got, []byte("ping")) {
+		t.Fatalf("forwarded datagram = %q, want %q", got, "ping")
+	}
+
+	// Return direction: a reply written back through the tunnel must reach the
+	// original UDP client. This is the behavior that issue #147 reports broken.
+	if _, err := proxySide.Write([]byte("pong")); err != nil {
+		t.Fatalf("proxy write: %v", err)
+	}
+
+	if err := client.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	n, err = client.Read(buf)
+	if err != nil {
+		t.Fatalf("client did not receive return traffic (issue #147): %v", err)
+	}
+	if got := buf[:n]; !bytes.Equal(got, []byte("pong")) {
+		t.Fatalf("client received %q, want %q", got, "pong")
+	}
+}


### PR DESCRIPTION
## What

Fixes #147: reverse UDP tunnels created with `listener_add --udp` break as soon as the redirect target sends traffic back. The first reply tears the listener down with "Listener ended without error".

## Root cause

A reverse UDP listener has the agent open a listening socket and relay both directions back to the proxy. The agent created that socket with `net.ListenUDP` (an unconnected `*net.UDPConn`) and relayed bytes with the generic `relay.StartRelay`, which uses `io.Copy` and closes both connections on the first error.

`io.Copy` drives the return path by calling `Write` on the listening socket. An unconnected UDP socket has no fixed peer, so `Write` fails with "destination address required". Because the relay closes on the first error, the whole listener was torn down the moment any reply came back.

The forward direction works because it only reads from the listening socket. Forward UDP tunneling (the agent dialing out) is unaffected because it uses a connected socket (`net.Dial` / `DialContext`) where `Write` works, which is exactly the difference from the broken reverse path.

## Fix

Add `relay.StartUDPListenerRelay`, which:

- reads datagrams with `ReadFromUDP`, recording the client source address
- forwards payloads to the proxy over the tunnel
- delivers return traffic with `WriteToUDP` to the recorded client address

and switch the agent UDP listener path to use it. The proxy side is unchanged (it already uses a connected socket).

## Scope

This targets the single-client case (the reported scenario and the common reverse-UDP use, e.g. DNS / SNMP / TFTP). The listening socket carries no per-client demultiplexing, so return traffic follows the most recently seen client. Full multi-client support would need per-client framing or streams like the TCP path's SockID design, and is left out to keep the change small.

## Note for review

`WriteToUDP` errors are treated as terminal, matching the existing `StartRelay` / `StartPacketRelay` contract. If you would prefer a long-lived listener to drop a single undeliverable datagram and keep running instead, I am happy to switch that one path to drop-and-continue.

## Testing

- New `pkg/relay/relay_test.go` exercises both directions over a `net.Pipe` tunnel with a real `net.ListenUDP` socket. It fails on the current code (the client times out waiting for the reply) and passes with the fix.
- `go test ./pkg/relay/ -race` passes.
- `go build ./cmd/agent ./cmd/proxy` both succeed.

Verified on linux/amd64 with Go 1.26.
