### PR TITLE
Fix non-constant format string vet errors

### DIFF
--- a/cmd/proxy/app/interfaces.go
+++ b/cmd/proxy/app/interfaces.go
@@ -430,7 +430,7 @@ func init() {
 								routes = append(routes, route.Destination)
 							}
 							routeStr := strings.Join(routes, ", ")
-							yellowRoutes := text.Colors{text.FgYellow}.Sprintf(routeStr)
+							yellowRoutes := text.Colors{text.FgYellow}.Sprintf("%s", routeStr)
 							displayName = fmt.Sprintf("%s %s", ifName, yellowRoutes)
 						}
 						ifaceOptions = append(ifaceOptions, displayName)

--- a/cmd/proxy/config/ifconfig.go
+++ b/cmd/proxy/config/ifconfig.go
@@ -79,9 +79,9 @@ func (i *InterfaceInfo) GetRouteString() string {
 	var stringBuffer []string
 	for _, route := range i.Routes {
 		if route.Active {
-			stringBuffer = append(stringBuffer, text.Colors{text.FgGreen}.Sprintf(route.Destination))
+			stringBuffer = append(stringBuffer, text.Colors{text.FgGreen}.Sprintf("%s", route.Destination))
 		} else {
-			stringBuffer = append(stringBuffer, text.Colors{text.FgYellow}.Sprintf(route.Destination))
+			stringBuffer = append(stringBuffer, text.Colors{text.FgYellow}.Sprintf("%s", route.Destination))
 		}
 	}
 	return strings.Join(stringBuffer, ",")


### PR DESCRIPTION
### Problem
`go vet` in recent Go versions flags passing a runtime string as the format argument to `(text.Colors).Sprintf`. Route destinations were passed directly:

    text.Colors{text.FgGreen}.Sprintf(route.Destination)

Any `%` in a route value would be misinterpreted as a format verb (e.g. output like `%!s(MISSING)`). More importantly, `make lint` runs `go vet` before every build target, so these vet errors make `make` fail before any binary is built.

### Fix
Pass the value via an explicit `"%s"` format argument at the three affected call sites in `cmd/proxy/config/ifconfig.go` (2) and `cmd/proxy/app/interfaces.go` (1). No behavioural change — output is identical for these string arguments.

### Testing
`go vet ./...` is clean after the change.