### PR TITLE
feat(web): expose agent liveness, removal, and certificate over the REST API

### DIFF
--- a/cmd/proxy/app/daemon.go
+++ b/cmd/proxy/app/daemon.go
@@ -17,6 +17,7 @@
 package app
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/static"
@@ -390,6 +391,61 @@ func StartLigoloApi() {
 
 		apiv1.GET("/agents", func(c *gin.Context) {
 			c.IndentedJSON(http.StatusOK, AgentList)
+		})
+
+		apiv1.DELETE("/agents/:id", func(c *gin.Context) {
+			agentParam := c.Param("id")
+			agentId, err := strconv.Atoi(agentParam)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, inputError)
+				return
+			}
+			// Look up under the lock (AgentList is a plain map guarded by AgentListMutex).
+			AgentListMutex.Lock()
+			agent, ok := AgentList[agentId]
+			AgentListMutex.Unlock()
+			if !ok {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid agent"})
+				return
+			}
+			// Stop the tunnel (route cleanup) and kill the live agent WITHOUT holding the
+			// lock: both can block / do network I/O, and the tunnel watchdog also takes it.
+			if agent.Running {
+				select {
+				case agent.CloseChan <- true:
+				default:
+				}
+				agent.Running = false
+			}
+			// Best-effort: ask a still-alive agent to terminate its process.
+			if agent.Alive() {
+				if err := agent.Kill(); err != nil {
+					logrus.Debugf("kill during agent removal (id %d) failed: %v", agentId, err)
+				}
+			}
+			// Purge the entry under the lock. ligolo otherwise never calls
+			// delete(AgentList, ...) anywhere, so dead/stale sessions linger until a
+			// proxy restart; this is what clears them.
+			AgentListMutex.Lock()
+			delete(AgentList, agentId)
+			AgentListMutex.Unlock()
+			c.JSON(http.StatusOK, gin.H{"message": "agent removed"})
+		})
+
+		apiv1.GET("/certificate", func(c *gin.Context) {
+			selfcrt, err := ProxyController.GetSelfCertificateSignature()
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			if selfcrt == nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "certificate is nil"})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{
+				"domain":      ProxyController.CertManagerConfig.SelfcertDomain,
+				"fingerprint": fmt.Sprintf("%X", sha256.Sum256(selfcrt.Certificate[0])),
+			})
 		})
 
 		apiv1.DELETE("/tunnel/:id", func(c *gin.Context) {

--- a/pkg/controller/agent.go
+++ b/pkg/controller/agent.go
@@ -110,17 +110,26 @@ func (la *LigoloAgent) MarshalJSON() ([]byte, error) {
 		RemoteAddr string
 		Interface  string
 		Running    bool
+		Online     bool
 		Listeners  []*proxy.LigoloListener
+	}
+
+	// RemoteAddr is nil-safe: an agent whose session has gone away is still listed
+	// (Online will be false), and must not panic when serialized.
+	remoteAddr := ""
+	if la.Session != nil {
+		remoteAddr = la.Session.RemoteAddr().String()
 	}
 
 	return json.Marshal(Session{
 		Name:       la.Name,
 		Running:    la.Running,
+		Online:     la.Alive(),
 		Listeners:  la.Listeners,
 		Network:    la.Network,
 		Interface:  la.Interface,
 		SessionID:  la.SessionID,
-		RemoteAddr: la.Session.RemoteAddr().String(),
+		RemoteAddr: remoteAddr,
 	})
 }
 


### PR DESCRIPTION
For transparency: These changes were mostly done using Claude Code Opus 4.8.

While implementing my own take on a web interface for ligolo-ng I discovered some gaps that could add valuable data for a client using the API.

The web API covers tunnels/interfaces/routes/listeners but not the agent lifecycle or some TUI-only metadata. This PR surfaces capabilities that already exist in the controller/TUI so web clients reach parity, and adds the missing ability to purge dead agents.

### Changes (additive only — no changes to existing fields/routes)

- **`Online` field** in `GET /api/v1/agents` — from the existing `LigoloAgent.Alive()`. Lets clients distinguish live sessions from stale/disconnected ones (the agent JSON previously only exposed `Running`). `RemoteAddr` marshalling is also made nil-safe so a gone session can't panic `MarshalJSON`.
- **`DELETE /api/v1/agents/:id`** — remove an agent: stop its tunnel if running, `Kill()` the remote process if the session is still alive, then `delete(AgentList, id)`. Note that `delete(AgentList, …)` is not called anywhere in the codebase today, so dead/stale sessions linger in `session_list` and the API until a proxy restart — this is the first way to purge them without one.
- **`GET /api/v1/certificate`** — returns the selfcert domain + SHA-256 fingerprint (REST equivalent of the `certificate_fingerprint` TUI command).

### Notes on the removal handler
All `AgentList` access is under `AgentListMutex` (read and delete), while the blocking/I/O steps (`CloseChan` send, `Kill()`) run outside the lock to avoid deadlock with the tunnel watchdog; the `CloseChan` send is non-blocking, and `Kill()` is gated behind `Alive()`. The existing handlers read `AgentList` unlocked — happy to match that style instead if you'd prefer consistency over the stricter locking.

### Testing
`gofmt`/`go vet` clean; builds for the targets. Verified at runtime against a real v0.9 agent:
- `Online` reports `true` while connected, `false` after disconnect.
- `DELETE /api/v1/agents/:id` on a live agent → entry purged from the list **and** the remote agent process terminates; a stale/dead session is also purged.
- `GET /api/v1/certificate` returns the fingerprint; an unknown route still 404s (confirming the new routes are properly registered).

_Method: connected a ligolo-ng v0.9 agent to a build of this branch and observed the above via the web API._